### PR TITLE
Remove emit_object_added() in restore path

### DIFF
--- a/log_manager.cpp
+++ b/log_manager.cpp
@@ -375,7 +375,6 @@ void Manager::restore()
             // validate the restored error entry id
             if (sanity(static_cast<uint32_t>(idNum), e->id()))
             {
-                e->emit_object_added();
                 if (e->severity() >= Entry::sevLowerLimit)
                 {
                     infoErrors.push_back(idNum);


### PR DESCRIPTION
Currently InterfacesAdded signal generating while restoring existing D-bus objects.

Which in-turn Causes Duplicate redfish events for  existing logging resources
This commit is to avoid D-bus signals while restoring existing D-bus objects.


Tested by:
Verified D-bus signals after restarting logging service
