### PR TITLE
PEL: Add error log entry for memory preserving reboot failure

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -634,6 +634,37 @@
         },
 
         {
+            "Name": "org.open_power.PHAL.Error.MPReboot",
+            "Subsystem": "cec_hardware",
+            "ComponentID": "0x3000",
+            "Severity": "unrecoverable",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3008",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [{"Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "Error during memory preserving reboot",
+                "Message": "Error during memory preserving reboot",
+                "Notes": [
+                    "Software error occured during memory preserving reboot"
+                ]
+            }
+        },
+
+        {
             "Name": "org.open_power.OCC.Firmware.PresenceMismatch",
             "Subsystem": "bmc_firmware",
             "ComponentID": "0x3200",


### PR DESCRIPTION
Added error log entry for memory preserving reboot might failure. 

https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/54427

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: Iceaf21c6527ccf93bcb11b8ec1c9c55dc3670ae0