### PR TITLE
PEL: phosphor-bmc-code-mgmt add HostFile

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -4775,6 +4775,47 @@
                 "Description": "The software image has an invalid signature.",
                 "Message": "The software image has an invalid signature"
             }
+        },
+
+        {
+            "Name" : "xyz.openbmc_project.Software.Version.Error.HostFile",
+            "Subsystem" : "bmc_firmware",
+            "ComponentID" : "0x3600",
+
+            "SRC" :
+            {
+                "ReasonCode" : "0x360A",
+                "Words6To9":
+                {
+                    "6":
+                    {
+                        "Description" : "Size of the current running partition",
+                        "AdditionalDataPropSource" : "CURRENT_FILE_SIZE"
+                    },
+                    "7":
+                    {
+                        "Description" : "Size of the read only partition",
+                        "AdditionalDataPropSource" : "EXPECTED_FILE_SIZE"
+                    }
+                }
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+            "Documentation" :
+            {
+                "Description" : "Corrupted or changed preserved file",
+                "Message" : "Partition was not preserved on reboot",
+                "Notes" : [
+                    "This error may occur if one of the partitions marked",
+                    "PRESERVED is either corrupted, or a change of size is ",
+                    "desired for a particular partition."
+                ]
+            }
         }
 
     ]


### PR DESCRIPTION
Add entries for errors that occur which are specific to
phosphor-bmc-code-mgmt. After code updates, and the system is
rebooted, there are partitions that should be preserved and not
overwritten. There needs to be PEL that specify if any of the
partitions have been corrupted or modified in a way that
prevents the copy from happening.