### PR TITLE
PEL: Sanitize D-Bus fields that come from PELs

### DIFF
--- a/extensions/openpower-pels/manager.cpp
+++ b/extensions/openpower-pels/manager.cpp
@@ -27,6 +27,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <locale>
 #include <xyz/openbmc_project/Common/error.hpp>
 #include <xyz/openbmc_project/Logging/Create/server.hpp>
 
@@ -735,7 +736,7 @@ std::string Manager::getEventId(const openpower::pels::PEL& pel) const
             str += getNumberString("%08X", value);
         }
     }
-    return str;
+    return sanitizeFieldForDBus(str);
 }
 
 void Manager::updateEventId(std::unique_ptr<openpower::pels::PEL>& pel)
@@ -747,6 +748,17 @@ void Manager::updateEventId(std::unique_ptr<openpower::pels::PEL>& pel)
     {
         entryN->second->eventId(eventIdStr);
     }
+}
+
+std::string Manager::sanitizeFieldForDBus(std::string field)
+{
+    std::for_each(field.begin(), field.end(), [](char& ch) {
+        if (((ch < ' ') || (ch > '~')) && (ch != '\n') && (ch != '\t'))
+        {
+            ch = ' ';
+        }
+    });
+    return field;
 }
 
 std::string Manager::getResolution(const openpower::pels::PEL& pel) const
@@ -812,7 +824,7 @@ std::string Manager::getResolution(const openpower::pels::PEL& pel) const
             }
         }
     }
-    return resolution;
+    return sanitizeFieldForDBus(resolution);
 }
 
 bool Manager::updateResolution(const openpower::pels::PEL& pel)

--- a/extensions/openpower-pels/manager.hpp
+++ b/extensions/openpower-pels/manager.hpp
@@ -273,6 +273,17 @@ class Manager : public PELInterface
      */
     void updateProgressSRC(std::unique_ptr<openpower::pels::PEL>& pel) const;
 
+    /**
+     * @brief Converts unprintable characters from the passed
+     *        in string to spaces so they won't crash D-Bus when
+     *        used as a property value.
+     *
+     * @param[in] field - The field to fix
+     *
+     * @return std::string - The string without non printable characters.
+     */
+    static std::string sanitizeFieldForDBus(std::string field);
+
   private:
     /**
      * @brief Adds a received raw PEL to the PEL repository

--- a/test/openpower-pels/pel_manager_test.cpp
+++ b/test/openpower-pels/pel_manager_test.cpp
@@ -1110,3 +1110,16 @@ TEST_F(ManagerTest, TestTerminateBitWithPELSevCriticalSysTerminate)
     auto& hexwords = pel.primarySRC().value()->hexwordData();
     EXPECT_EQ(hexwords[3] & 0x20000000, 0x20000000);
 }
+
+TEST_F(ManagerTest, TestSanitizeFieldforDBus)
+{
+    std::string base{"(test0!}\n\t ~"};
+    auto string = base;
+    string += char{' ' - 1};
+    string += char{'~' + 1};
+    string += char{0};
+    string += char{static_cast<char>(0xFF)};
+
+    // convert the last four chars to spaces
+    EXPECT_EQ(Manager::sanitizeFieldForDBus(string), base + "    ");
+}


### PR DESCRIPTION
The Resolution D-Bus property is filled with values from the PEL callout
fields like the serial and part numbers.  These fields usually come from
EEPROMs, and may not necessarily be valid printable values if the code
that creates the PEL doesn't sanitize the values first.  If any of the
characters were invalid, the daemon would crash when D-Bus broker
disconnects it from D-Bus since it doesn't allow invalid values on
D-Bus.

Prevent this crash by converting any non printable characters in the
Resolution property to spaces.  This also sanitizes the EventId property
which contains the SRC ASCII string and hex words just to be safe.

This is really just a concern for non-BMC created PELs, since the BMC
code that reads EEPROMs already sanitizes the values when it reads them,
but PELs have come in from other subsystems that don't.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: If0e80fd9db27446f5367ed046e4bca2eb62e3fb2