### PR TITLE
PEL: Error interface for missing essential fru. SW553167

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -4373,14 +4373,21 @@
                 }
             },
 
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
             "Documentation": {
                 "Description": "GPIO line error",
                 "Message": "GPIO line couldn't be found or read.",
                 "Notes": [
-                    "The BMC could not access a GPIO line. This generally means that the",
-                    " hardware had issues toggling the line and/or the device driver has",
-                    " not exposed the GPIO line to userspace due to underlying I2C issues.",
-                    " The I2C path will be called out."
+                    "The BMC could not access a GPIO line. This can be a hardware issue",
+                    " or driver issue. Since a hardware or a software issue cannot be",
+                    " differentiated, the BMC code will be called out."
                 ]
             }
         },
@@ -4413,6 +4420,30 @@
                     "mismatch in cache data and hardware data.",
                     "The record and keyword causing the failure is captured in",
                     "additional data."
+                ]
+            }
+        },
+
+        {
+            "Name": "com.ibm.VPD.Error.RequiredFRUMissing",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x4009",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation": {
+                "Description": "Essential FRU check.",
+                "Message": "Essential FRU check failed",
+                "Notes": [
+                    "This error occurs when VPD manager service detects any",
+                    "missing essential FRU. These are FRUs which are required",
+                    "to be present in the system at the time of power on.",
+                    "The inventory path is captured in additional data."
                 ]
             }
         },


### PR DESCRIPTION
The commit defines interface for essential fru missing case.
Essential frus are the ones which are required to be present
in the system at power on state.

The commit also modifies the entry related GPIO line error,
where because of the ambiguity behind GPIO line error, bmc
code will be called out.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
Change-Id: I167c45ed384e04676d66887bcecb4e7e00f16709