### PR TITLE
PEL: Fix in getting processor position from SRC6

### DIFF
--- a/extensions/openpower-pels/sbe_ffdc_handler.cpp
+++ b/extensions/openpower-pels/sbe_ffdc_handler.cpp
@@ -54,7 +54,7 @@ SbeFFDC::SbeFFDC(const AdditionalData& aData, const PelFFDC& files)
     }
     try
     {
-        procPos = std::stoi((src6.value()).substr(0, 4));
+        procPos = (std::stoi(src6.value()) & 0xFFFF0000) >> 16;
     }
     catch (const std::exception& err)
     {


### PR DESCRIPTION
The value in the SRC6 is stored in the decimal form so
that string needs to be converted to integer first to get the
processor position from 0:15 bits.

TESTS:
Executed the test to create PEL with SBE FFDC, there was
no crash.

Jun 23 06:30:46 p10bmc phosphor-log-manager[7794]: Created PEL 0x500010c9 (BMC ID 282) with SRC BD123500
Jun 23 06:30:46 p10bmc openpower-proc-control[17085]: exception raised
Jun 23 06:30:46 p10bmc openpower-proc-control[17085]: Enter: mpiplEnter(/proc2)
Jun 23 06:30:46 p10bmc openpower-proc-control[17085]: /proc2 CFAM(0x2986) : 0x2
Jun 23 06:30:46 p10bmc openpower-proc-control[17085]: /proc2 CFAM(0x2809) : 0x8366018F
Jun 23 06:30:46 p10bmc openpower-proc-control[17085]: /proc2 CFAM(0x282A) : 0x9A609A6
Jun 23 06:30:46 p10bmc openpower-proc-control[17085]: /proc2 CFAM(0x2829) : 0x99209A6
Jun 23 06:30:46 p10bmc openpower-proc-control[17085]: /proc2 CFAM(0x1007) : 0xC02083F8
Jun 23 06:30:46 p10bmc phosphor-log-manager[7794]: Created PEL 0x500010ca (BMC ID 283) with SRC BD123500
Jun 23 06:30:46 p10bmc openpower-proc-control[17086]: exception raised
Jun 23 06:30:46 p10bmc openpower-proc-control[17086]: Enter: mpiplEnter(/proc3)
Jun 23 06:30:46 p10bmc openpower-proc-control[17086]: /proc3 CFAM(0x2986) : 0x2
Jun 23 06:30:46 p10bmc openpower-proc-control[17086]: /proc3 CFAM(0x2809) : 0x8366018F
Jun 23 06:30:46 p10bmc openpower-proc-control[17086]: /proc3 CFAM(0x282A) : 0x9740960
Jun 23 06:30:46 p10bmc openpower-proc-control[17086]: /proc3 CFAM(0x2829) : 0x9560974
Jun 23 06:30:46 p10bmc openpower-proc-control[17086]: /proc3 CFAM(0x1007) : 0xC02083F8
Jun 23 06:30:46 p10bmc phosphor-log-manager[7794]: Created PEL 0x500010cb (BMC ID 284) with SRC BD123500
Jun 23 06:30:46 p10bmc openpower-proc-control[17083]: exception raised
Jun 23 06:30:46 p10bmc openpower-proc-control[17083]: Enter: mpiplEnter(/proc0)
Jun 23 06:30:46 p10bmc openpower-proc-control[17083]: /proc0 CFAM(0x2986) : 0x1
Jun 23 06:30:46 p10bmc openpower-proc-control[17083]: /proc0 CFAM(0x2809) : 0x8366018F
Jun 23 06:30:46 p10bmc openpower-proc-control[17083]: /proc0 CFAM(0x282A) : 0x9560942
Jun 23 06:30:46 p10bmc openpower-proc-control[17083]: /proc0 CFAM(0x2829) : 0x92E0974
Jun 23 06:30:46 p10bmc openpower-proc-control[17083]: /proc0 CFAM(0x1007) : 0xC02083F8
Jun 23 06:30:46 p10bmc openpower-proc-control[17070]: Memory preserving reboot failed
Jun 23 06:30:46 p10bmc phosphor-log-manager[7794]: Created PEL 0x500010cc (BMC ID 285) with SRC BD123500
Jun 23 06:30:46 p10bmc openpower-proc-control[17084]: exception raised
Jun 23 06:30:46 p10bmc openpower-proc-control[17084]: Enter: mpiplEnter(/proc1)
Jun 23 06:30:46 p10bmc openpower-proc-control[17084]: /proc1 CFAM(0x2986) : 0x2
Jun 23 06:30:46 p10bmc openpower-proc-control[17084]: /proc1 CFAM(0x2809) : 0x8366018F
Jun 23 06:30:46 p10bmc openpower-proc-control[17084]: /proc1 CFAM(0x282A) : 0x9B00988
Jun 23 06:30:46 p10bmc openpower-proc-control[17084]: /proc1 CFAM(0x2829) : 0x9880992
Jun 23 06:30:46 p10bmc openpower-proc-control[17084]: /proc1 CFAM(0x1007) : 0xC02083F8
Jun 23 06:30:46 p10bmc openpower-proc-control[17070]: Memory preserving reboot failed
Jun 23 06:30:46 p10bmc openpower-proc-control[17070]: Memory preserving reboot failed
Jun 23 06:30:46 p10bmc openpower-proc-control[17070]: Memory preserving reboot failed
Jun 23 06:30:46 p10bmc systemd[1]: op-enter-mpreboot@0.service: Main process exited, code=exited, status=1/FAILURE
Jun 23 06:30:46 p10bmc systemd[1]: op-enter-mpreboot@0.service: Failed with result 'exit-code'.
Jun 23 06:30:46 p10bmc systemd[1]: Failed to start Start memory preserving reboot host0.

Signed-off-by: Dhruvaraj Subhashchandran <dhruvaraj@in.ibm.com>
Change-Id: I2a1f6f7daebe9a01e00241c9f3587dd09f8668fb