### PR TITLE
PEL: change OCC control SRCs to 0x2600

### DIFF
--- a/extensions/openpower-pels/registry/O_component_ids.json
+++ b/extensions/openpower-pels/registry/O_component_ids.json
@@ -1,11 +1,11 @@
 {
     "1000": "bmc common function",
     "2000": "bmc error logging",
+    "2600": "bmc occ control",
     "2700": "bmc power and thermal",
     "2800": "bmc fans",
     "3000": "bmc host processor control",
     "3100": "bmc hardware isolation",
-    "3200": "bmc occ control",
     "3400": "bmc state manager",
     "3500": "bmc common host processor errors",
     "3600": "bmc code management",

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -667,12 +667,12 @@
         {
             "Name": "org.open_power.OCC.Firmware.PresenceMismatch",
             "Subsystem": "bmc_firmware",
-            "ComponentID": "0x3200",
+            "ComponentID": "0x2600",
             "Severity": "predictive",
 
             "SRC":
             {
-                "ReasonCode": "0x3201",
+                "ReasonCode": "0x2681",
                 "Words6To9":
                 {
                 }
@@ -700,12 +700,12 @@
         {
             "Name": "org.open_power.OCC.Device.SafeState",
             "Subsystem": "processor_chip",
-            "ComponentID": "0x3200",
+            "ComponentID": "0x2600",
             "Severity": "non_error",
 
             "SRC":
             {
-                "ReasonCode": "0x3202",
+                "ReasonCode": "0x2682",
                 "Words6To9":
                 {
                 }
@@ -725,12 +725,12 @@
         {
             "Name": "org.open_power.OCC.Device.ReadFailure",
             "Subsystem": "cec_chip_iface",
-            "ComponentID": "0x3200",
+            "ComponentID": "0x2600",
             "Severity": "predictive",
 
             "SRC":
             {
-                "ReasonCode": "0x3203",
+                "ReasonCode": "0x2683",
                 "Words6To9":
                 {
                 }


### PR DESCRIPTION
change OCC reason code to 0x2681, 0x2682, 0x2683.
Tested: error logs built.
Signed-off-by: Sheldon Bailey <baileysh@us.ibm.com>
Change-Id: Ic7748721664511dc818e68894f4369efaa0aabc0