### PR TITLE
Overtemp callouts

### DIFF
--- a/extensions/openpower-pels/pel_values.cpp
+++ b/extensions/openpower-pels/pel_values.cpp
@@ -241,7 +241,7 @@ const std::map<std::string, std::string> symbolicFRUs = {
     {"ambient_temp_back", "AMBBACK"}, {"ambient_perf_loss", "AMBPERF"},
     {"ac_module", "ACMODUL"},         {"fan_cable", "FANCBL"},
     {"cable_continued", "CBLCONT"},   {"altitude", "ALTTUDE"},
-    {"pcie_hot_plug", "PCIEHP"}};
+    {"pcie_hot_plug", "PCIEHP"},      {"overtemp", "OVERTMP"}};
 
 PELValues::const_iterator findByValue(uint32_t value, const PELValues& fields)
 {

--- a/extensions/openpower-pels/registry.cpp
+++ b/extensions/openpower-pels/registry.cpp
@@ -562,7 +562,14 @@ std::vector<RegistryCallout>
     if (it == callouts.end())
     {
         // This can happen if not all possible values were in the
-        // message registry and that's fine.
+        // message registry and that's fine.  There may be a
+        // "CalloutsWhenNoADMatch" section that contains callouts
+        // to use in this case.
+        if (json.contains("CalloutsWhenNoADMatch"))
+        {
+            return getCalloutsWithoutAD(json["CalloutsWhenNoADMatch"],
+                                        systemNames);
+        }
         return std::vector<RegistryCallout>{};
     }
 

--- a/extensions/openpower-pels/registry/README.md
+++ b/extensions/openpower-pels/registry/README.md
@@ -365,6 +365,47 @@ When it was 1, P1-C6 was called out.  Note that the same 'Callouts' array is
 used as in the previous example, so these callouts can also depend on the
 system type.
 
+If it's desired to use a different set of callouts when there isn't a match
+on the AdditionalData field, one can use CalloutsWhenNoADMatch.  In the
+following example, the 'air_mover' callout will be added if 'PROC_NUM' isn't
+0.  'CalloutsWhenNoADMatch' has the same schema as the 'Callouts' section.
+
+```
+"CalloutsUsingAD":
+{
+    "ADName": "PROC_NUM",
+    "CalloutsWithTheirADValues":
+    [
+        {
+            "ADValue": "0",
+            "Callouts":
+            [
+                {
+                    "CalloutList":
+                    [
+                        {
+                            "Priority": "high",
+                            "LocCode": "P1-C5"
+                        }
+                    ]
+                }
+            ]
+        },
+    ],
+    "CalloutsWhenNoADMatch": [
+        {
+            "CalloutList": [
+                {
+                    "Priority": "high",
+                    "SymbolicFRU": "air_mover"
+                }
+            ]
+        }
+    ]
+}
+
+```
+
 #### CalloutType
 This field can be used to modify the failing component type field in the
 callout when the default doesn\'t fit:

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -3677,6 +3677,16 @@
                             }
                         ]
                     }
+                ],
+                "CalloutsWhenNoADMatch": [
+                    {
+                        "CalloutList": [
+                            {
+                                "Priority": "high",
+                                "SymbolicFRU": "overtemp"
+                            }
+                        ]
+                    }
                 ]
             },
 
@@ -3756,6 +3766,16 @@
                             }
                         ]
                     }
+                ],
+                "CalloutsWhenNoADMatch": [
+                    {
+                        "CalloutList": [
+                            {
+                                "Priority": "high",
+                                "SymbolicFRU": "overtemp"
+                            }
+                        ]
+                    }
                 ]
             },
 
@@ -3832,6 +3852,16 @@
                                 "CalloutList": [
                                     { "Priority": "high", "SymbolicFRU": "ambient_temp" }
                                 ]
+                            }
+                        ]
+                    }
+                ],
+                "CalloutsWhenNoADMatch": [
+                    {
+                        "CalloutList": [
+                            {
+                                "Priority": "high",
+                                "SymbolicFRU": "overtemp"
                             }
                         ]
                     }

--- a/extensions/openpower-pels/registry/schema/schema.json
+++ b/extensions/openpower-pels/registry/schema/schema.json
@@ -656,14 +656,16 @@
 
         "calloutsUsingAD":
         {
-            "description": "This contains the callouts that can be specified based on a value in the AdditionalData property..",
+            "description": "This contains the callouts that can be specified based on a value in the AdditionalData property.",
             "type": "object",
 
             "properties":
             {
                 "ADName": {"$ref": "#/definitions/adName" },
                 "CalloutsWithTheirADValues":
-                    {"$ref": "#/definitions/calloutsWithTheirADValues" }
+                    {"$ref": "#/definitions/calloutsWithTheirADValues" },
+                "CalloutsWhenNoADMatch":
+                    {"$ref": "#/definitions/calloutsWhenNoADMatch" }
             },
             "additionalProperties": false,
             "required": ["ADName", "CalloutsWithTheirADValues"],
@@ -695,6 +697,12 @@
                     ]
                 }
             ]
+        },
+
+        "calloutsWhenNoADMatch":
+        {
+            "description": "This contains the callouts to use when a match in the 'CalloutsWithTheirADValues array isn't found.",
+            "$ref": "#/definitions/callouts"
         }
     }
 }

--- a/extensions/openpower-pels/registry/schema/schema.json
+++ b/extensions/openpower-pels/registry/schema/schema.json
@@ -454,7 +454,7 @@
         {
             "description": "The symbolic FRU callout.",
             "type": "string",
-            "enum": ["service_docs", "pwrsply", "air_mover", "pgood_part", "usb_pgood", "ambient_temp", "ambient_temp_back", "ambient_perf_loss", "ac_module", "fan_cable", "cable_continued", "altitude", "pcie_hot_plug"]
+            "enum": ["service_docs", "pwrsply", "air_mover", "pgood_part", "usb_pgood", "ambient_temp", "ambient_temp_back", "ambient_perf_loss", "ac_module", "fan_cable", "cable_continued", "altitude", "pcie_hot_plug", "overtemp"]
         },
 
         "symbolicFRUTrusted":

--- a/test/openpower-pels/registry_test.cpp
+++ b/test/openpower-pels/registry_test.cpp
@@ -662,6 +662,54 @@ TEST_F(RegistryTest, TestGetCallouts)
             EXPECT_TRUE(callouts.empty());
         }
     }
+
+    {
+        // Callouts with a 'CalloutsWhenNoADMatch' section that will
+        // be used when the AdditionalData value doesn't match.
+        auto json = R"(
+        {
+            "ADName": "PROC_NUM",
+            "CalloutsWithTheirADValues":
+            [
+                {
+                    "ADValue": "0",
+                    "Callouts":
+                    [
+                        {
+                            "CalloutList":
+                            [
+                                {
+                                    "Priority": "high",
+                                    "LocCode": "P0-C0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "CalloutsWhenNoADMatch": [
+                {
+                    "CalloutList": [
+                        {
+                            "Priority": "medium",
+                            "LocCode": "P1-C1"
+                        }
+                    ]
+                }
+            ]
+        })"_json;
+
+        // There isn't an entry in the JSON for a PROC_NUM of 8
+        // so it should choose the P1-C1 callout.
+        std::vector<std::string> adData{"PROC_NUM=8"};
+        AdditionalData ad{adData};
+        names.clear();
+
+        auto callouts = Registry::getCallouts(json, names, ad);
+        EXPECT_EQ(callouts.size(), 1);
+        EXPECT_EQ(callouts[0].priority, "medium");
+        EXPECT_EQ(callouts[0].locCode, "P1-C1");
+    }
 }
 
 TEST_F(RegistryTest, TestNoSubsystem)


### PR DESCRIPTION
These commits add the OVERTMP symbolic FRU as a high callout to the perfloss, warning, and critical high temperature PELs.  It uses a new CalloutsWhenNoADMatch message registry field to handle doing it for all sensors listed in the ADValue field that aren't the ambient sensor.