### PR TITLE
PEL: Add message registry for logging clock debug info

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -714,6 +714,31 @@
         },
 
         {
+            "Name": "org.open_power.PHAL.Info.ClockDailyLog",
+            "Subsystem": "cec_clocks",
+            "ComponentID": "0x3000",
+            "Severity": "non_error",
+            "ActionFlags": [ "report", "call_home" ],
+
+            "SRC":
+            {
+                "ReasonCode": "0x300A",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Documentation":
+            {
+                "Description": "Informational error to house clock debug info",
+                "Message": "Informational error to house clock debug info",
+                "Notes": [
+                    "User data includes processor and clock register state information."
+                ]
+            }
+        },
+
+        {
             "Name": "org.open_power.OCC.Firmware.PresenceMismatch",
             "Subsystem": "bmc_firmware",
             "ComponentID": "0x2600",


### PR DESCRIPTION
Added message registry for logging clock debug information daily. This error is logged as informational and enabled the required fields to reports externally.

Gerrit Link : https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/56994
