### PR TITLE
PEL: Add registry for logging Guard partition access error

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -665,6 +665,38 @@
         },
 
         {
+            "Name": "org.open_power.PHAL.Error.GuardPartitionAccess",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x3000",
+            "Severity": "predictive",
+
+            "SRC":
+            {
+                "ReasonCode": "0x3009",
+                "Words6To9":
+                {
+                }
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation":
+            {
+                "Description": "Guard partition access failure",
+                "Message": "Guard partition access failure",
+                "Notes": [
+                    "User data and journal should contain more information"
+                ]
+            }
+        },
+
+        {
             "Name": "org.open_power.OCC.Firmware.PresenceMismatch",
             "Subsystem": "bmc_firmware",
             "ComponentID": "0x2600",


### PR DESCRIPTION
Added message registry for logging guard partition access error At the time of IPLing if we are unable to access guard partition, this entry is logged as informational and the required fields are enabled to reports externally.

Signed-off-by: deepakala karthikeyan <deepakala.karthikeyan@ibm.com>
Change-Id: I7874f81932c12043f5f8641058fcf59e60d63410