### PR TITLE
Don't install elog-gen.py and mako templates

### DIFF
--- a/gen/meson.build
+++ b/gen/meson.build
@@ -4,10 +4,10 @@ sdbuspp_gen_meson_ver = run_command(
     '--version',
 ).stdout().strip().split('\n')[0]
 
-if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 4'
+if sdbuspp_gen_meson_ver != 'sdbus++-gen-meson version 3'
     warning('Generated meson files from wrong version of sdbus++-gen-meson.')
     warning(
-        'Expected "sdbus++-gen-meson version 4", got:',
+        'Expected "sdbus++-gen-meson version 3", got:',
         sdbuspp_gen_meson_ver
     )
 endif

--- a/gen/xyz/openbmc_project/Logging/Internal/Manager/meson.build
+++ b/gen/xyz/openbmc_project/Logging/Internal/Manager/meson.build
@@ -3,7 +3,6 @@ generated_sources += custom_target(
     'xyz/openbmc_project/Logging/Internal/Manager__cpp'.underscorify(),
     input: [ '../../../../../../xyz/openbmc_project/Logging/Internal/Manager.interface.yaml',  ],
     output: [ 'server.cpp', 'server.hpp', 'client.hpp',  ],
-    depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'cpp',
         '--output', meson.current_build_dir(),

--- a/gen/xyz/openbmc_project/Logging/Internal/meson.build
+++ b/gen/xyz/openbmc_project/Logging/Internal/meson.build
@@ -4,7 +4,6 @@ generated_others += custom_target(
     'xyz/openbmc_project/Logging/Internal/Manager__markdown'.underscorify(),
     input: [ '../../../../../xyz/openbmc_project/Logging/Internal/Manager.interface.yaml',  ],
     output: [ 'Manager.md' ],
-    depend_files: sdbusplusplus_depfiles,
     command: [
         sdbuspp_gen_meson_prog, '--command', 'markdown',
         '--output', meson.current_build_dir(),

--- a/meson.build
+++ b/meson.build
@@ -18,10 +18,6 @@ systemd_dep = dependency('systemd')
 sdbusplus_dep = dependency('sdbusplus')
 sdbusplusplus_prog = find_program('sdbus++', native: true)
 sdbuspp_gen_meson_prog = find_program('sdbus++-gen-meson', native: true)
-sdbusplusplus_depfiles = files()
-if sdbusplus_dep.type_name() == 'internal'
-    sdbusplusplus_depfiles = subproject('sdbusplus').get_variable('sdbusplusplus_depfiles')
-endif
 
 pdi_dep = dependency('phosphor-dbus-interfaces')
 

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,9 +1,4 @@
 tool_dir = meson.current_source_dir()
 
 elog_gen = files('elog-gen.py')
-install_data(
-    elog_gen,
-    install_dir: get_option('datadir') / 'phosphor-logging' / 'elog' / 'tools',
-)
-
 subdir('phosphor-logging/templates')

--- a/tools/phosphor-logging/templates/meson.build
+++ b/tools/phosphor-logging/templates/meson.build
@@ -1,11 +1,1 @@
 template_elog_gen = files('elog-gen-template.mako.hpp')
-template_elog_lookup = files('elog-lookup-template.mako.cpp')
-template_elog_process_metadata = files('elog-process-metadata.mako.cpp')
-
-install_data(
-    template_elog_gen,
-    template_elog_lookup,
-    template_elog_process_metadata,
-    install_dir : get_option('datadir') / 'phosphor-logging' / 'elog' /
-        'tools' / 'phosphor-logging' / 'templates',
-)


### PR DESCRIPTION
These were actually getting installed into the BMC flash image, which isn't desirable.  Bitbake runs these straight from the source tree so removing this doesn't affect builds.

This does mean they wouldn't be installed into usr/share in the SDK, but it's not like that was in $PATH anyway.

https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/57999

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I65fff38bcdf82e8b812177d65a6918fc9abbd5fd