### PR TITLE
PEL: Set Action Flags for UnTarFailure to report only

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -4808,6 +4808,7 @@
             "Name": "xyz.openbmc_project.Software.Image.Error.UnTarFailure",
             "Subsystem": "bmc_firmware",
             "ComponentID": "0x3600",
+            "ActionFlags": ["report"],
             "SRC":
             {
                 "ReasonCode": "0x3603",


### PR DESCRIPTION
The UnTarFailure can be caused by uploading accidentally the wrong image format, and therefore does not require to be a call-home error since the user can figure that error themselves, or if they need to, they can call home themselves.

Set the Action Flags to report to override the default that adds the call home flag, instead of changing the severity to non_error, in this way the error severity is preserved and it's viewable by all users.

Tested: Error log diff:
<     "Action Flags": [
<                                 "Service Action Required",
<                                 "Report Externally",
<                                 "HMC Call Home"
---
>     "Action Flags": [
>                                 "Report Externally"

The error log is present in the GUI.

Change-Id: I7b6a997e55cf05e74d627b1478edb8a5bff01961
Signed-off-by: Adriana Kobylak <anoo@us.ibm.com>