### PR TITLE
1020: PEL:Procedure to correct system VPD issues

### DIFF
--- a/extensions/openpower-pels/pel_values.cpp
+++ b/extensions/openpower-pels/pel_values.cpp
@@ -228,6 +228,8 @@ const std::map<std::string, std::string> maintenanceProcedures = {
     {"power_overcurrent", "BMC0005"},
     // An unrecoverable event occurred, look for previous errors for the cause
     {"find_sue_root_cause", "BMC0006"},
+    // Correct system backplane VPD mismatch
+    {"system_vpd_correction", "BMC0007"},
 };
 
 /**

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -4350,6 +4350,17 @@
                 }
             },
 
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        {
+                            "Priority": "high",
+                            "Procedure": "system_vpd_correction"
+                        }
+                    ]
+                }
+            ],
+
             "Documentation": {
                 "Description": "System VPD restore failed",
                 "Message": "A system VPD restoration error occurred.",
@@ -4469,7 +4480,10 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        {
+                            "Priority": "high",
+                            "Procedure": "system_vpd_correction"
+                        }
                     ]
                 }
             ],

--- a/extensions/openpower-pels/registry/schema/schema.json
+++ b/extensions/openpower-pels/registry/schema/schema.json
@@ -467,7 +467,15 @@
         {
             "description": "The maintenance procedure callout.",
             "type": "string",
-            "enum": ["bmc_code", "next_level_support", "sbe_code", "fsi_path", "power_overcurrent", "find_sue_root_cause"]
+            "enum": [
+                "bmc_code",
+                "next_level_support",
+                "sbe_code",
+                "fsi_path",
+                "power_overcurrent",
+                "find_sue_root_cause",
+                "system_vpd_correction"
+            ]
         },
 
         "useInventoryLocCode":


### PR DESCRIPTION
#### PEL:Procedure to correct system VPD issues
```
This commit adds a new callout procedure "BMC0007" to correct
 * system backplane VPD mismatch between hardware value and
   backed up value.
 * system backplane data being blank on both hardware and in
   backup.

Test:
Tested that newly added callout procedure has been picked
when there is a system VPD mismatch and when the data is
blank.

peltool -i 0x500024AB
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x4000",
    "Created at":               "12/05/2022 05:58:47",
    "Committed at":             "12/05/2022 05:58:47",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x500024AB",
    "Entry Id":                 "0x500024AB",
    "BMC Event Log Id":         "314"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "0x2000",
    "Subsystem":                "CEC Hardware - VPD Interface",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Predictive Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Not Sent"
},
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "0x4000",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E2D",
    "Terminate FW Error":       "False",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "A system VPD restoration error"
                                "occurred."
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "BD554008",
    "Hex Word 2":               "00080055",
    "Hex Word 3":               "2E2D0010",
    "Hex Word 4":               "00000000",
    "Hex Word 5":               "00000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000",
    "Callout Section": {
        "Callout Count":        "2",
        "Callouts": [{
            "FRU Type":         "Normal Hardware FRU",
            "Priority":         "Mandatory, replace all with this"
                                "type as a unit",
            "Location Code":    "U78DA.ND0.WZS007H-P0",
            "Part Number":      "02WG676",
            "CCIN":             "2E2D",
            "Serial Number":    "YF33UF19Y007"
        }, {
            "FRU Type":         "Maintenance Procedure Required",
            "Priority":         "Mandatory, replace all with this"
                                "type as a unit",
            "Procedure":        "BMC0007"
        }]
    }
},
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Reporting Machine Type":   "9105-22B",
    "Reporting Serial Number":  "1392BE0",
    "FW Released Ver":          "",
    "FW SubSys Version":        "fw1040.00-1.2",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "BD554008_2E2D0010"
},
"Failing MTMS": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "0x2000",
    "Machine Type Model":       "9105-22B",
    "Serial Number":            "1392BE0"
},
"User Data 0": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "BMCLoad": "0.22 0.41 0.33",
    "BMCState": "Ready",
    "BMCUptime": "0y 0d 0h 13m 6s",
    "BootState": "Unspecified",
    "ChassisState": "Off",
    "FW Version ID": "fw1040.00-1.2-2-g1859836242-dirty",
    "HostState": "Off",
    "System IM": "50001001"
},
"User Data 1": {
    "Section Version": "1",
    "Sub-section type": "1",
    "Created by": "0x2000",
    "CALLOUT_INVENTORY_PATH": "/xyz/openbmc_project/inventory/system"
                              "/chassis/motherboard",
    "DESCRIPTION": "VPD data mismatch on cache and hardware for"
                   "record: LXR0 and keyword: LX",
    "Value on Cache: ": "0x31 0x0 0x4 0x1 0x0 0x30 0x0 0x71 ",
    "Value read from EEPROM: ": "0x64 0x65 0x4 0x1 0x0 0x30 0x0 0x71 "
}
}

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>
Change-Id: I738542d55781538285cb3747461929195cbd6d48
```