### PR TITLE
dbus: add dbus activation support

### DIFF
--- a/dist/dbus/xyz.openbmc_project.Logging.service
+++ b/dist/dbus/xyz.openbmc_project.Logging.service
@@ -1,0 +1,5 @@
+[D-BUS Service]
+Name=xyz.openbmc_project.Logging
+Exec=/bin/false
+User=root
+SystemdService=dbus-xyz.openbmc_project.Logging.service

--- a/dist/meson.build
+++ b/dist/meson.build
@@ -12,3 +12,10 @@ install_data(
     'busconfig/phosphor-rsyslog-config.conf',
     install_dir: get_option('datadir') / 'dbus-1' / 'system.d',
 )
+
+dbus_system_bus_services_dir = dependency('dbus-1').get_variable(
+    pkgconfig: 'system_bus_services_dir',
+    pkgconfig_define: ['prefix', get_option('prefix')])
+install_data(
+    'dbus/xyz.openbmc_project.Logging.service',
+    install_dir: dbus_system_bus_services_dir)

--- a/dist/xyz.openbmc_project.Logging.service
+++ b/dist/xyz.openbmc_project.Logging.service
@@ -9,3 +9,4 @@ BusName=xyz.openbmc_project.Logging
 
 [Install]
 WantedBy=multi-user.target
+Alias=dbus-xyz.openbmc_project.Logging.service


### PR DESCRIPTION
Add support for dbus activation of phosphor-logging. This will ensure users of the logging library for calls like "commit" will automatically have the phosphor-logging service start (if not already running) and not need to put this dependency in their service files.

Tested:
- Stopped xyz.openbmc_project.Logging.service and then used busctl to create an error log. Verified that xyz.openbmc_project.Logging.service was automatically started and the error was created.


Change-Id: I9134851c075dbb717f832422f55e2eeee31f823b