### PR TITLE
1020: PEL: Support for CheckstopFlag msg reg field

### DIFF
--- a/extensions/openpower-pels/registry.cpp
+++ b/extensions/openpower-pels/registry.cpp
@@ -189,6 +189,11 @@ uint8_t getSRCType(const nlohmann::json& src, const std::string& name)
     return type;
 }
 
+bool getSRCCheckstopFlag(const nlohmann::json& src)
+{
+    return src["CheckstopFlag"].get<bool>();
+}
+
 std::optional<std::map<SRC::WordNum, SRC::AdditionalDataField>>
     getSRCHexwordFields(const nlohmann::json& src, const std::string& name)
 {
@@ -680,6 +685,11 @@ std::optional<Entry> Registry::lookup(const std::string& name, LookupType type,
             if (src.contains("SymptomIDFields"))
             {
                 entry.src.symptomID = helper::getSRCSymptomIDFields(src, name);
+            }
+
+            if (src.contains("CheckstopFlag"))
+            {
+                entry.src.checkstopFlag = helper::getSRCCheckstopFlag(src);
             }
 
             auto& doc = (*e)["Documentation"];

--- a/extensions/openpower-pels/registry.hpp
+++ b/extensions/openpower-pels/registry.hpp
@@ -103,7 +103,12 @@ struct SRC
     using AdditionalDataField = std::tuple<std::string, std::string>;
     std::optional<std::map<WordNum, AdditionalDataField>> hexwordADFields;
 
-    SRC() : type(0), reasonCode(0)
+    /**
+     * @brief If the checkstop flag should be set in hex word 5
+     */
+    bool checkstopFlag;
+
+    SRC() : type(0), reasonCode(0), checkstopFlag(false)
     {
     }
 };

--- a/extensions/openpower-pels/registry/README.md
+++ b/extensions/openpower-pels/registry/README.md
@@ -218,6 +218,15 @@ words will be set to zero in the PEL.
 }
 ```
 
+### SRC Checkstop Flag
+
+This is used to indicate the PEL is for a hardware checkstop, and causes bit 0
+in hex word 5 of the SRC to be set.
+
+```json
+"CheckstopFlag": true
+```
+
 ### Documentation Fields
 The documentation fields are used by PEL parsers to display a human readable
 description of a PEL.  They are also the source for the Redfish event log

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -1474,6 +1474,7 @@
             {
                 "ReasonCode": "0xE510",
                 "SymptomIDFields": [ "SRCWord6", "SRCWord7", "SRCWord8" ],
+                "CheckstopFlag": true,
                 "Words6To9":
                 {
                     "6":

--- a/extensions/openpower-pels/registry/schema/schema.json
+++ b/extensions/openpower-pels/registry/schema/schema.json
@@ -104,7 +104,8 @@
 
                 "SymptomIDFields": {"$ref": "#/definitions/symptomID" },
 
-                "Words6To9": {"$ref": "#/definitions/srcWords6To9" }
+                "Words6To9": {"$ref": "#/definitions/srcWords6To9" },
+                "CheckstopFlag": {"$ref": "#/definitions/checkstopFlag" }
             },
 
             "required": ["ReasonCode", "Words6To9"],
@@ -136,6 +137,12 @@
             "description": "The first byte of the SRC ASCII string. Optional and defaults to BD.  The '11' SRC is only to be used for events related to power.",
             "type": "string",
             "enum": ["BD", "11"]
+        },
+
+        "checkstopFlag":
+        {
+            "description": "Indicates the SRC is for a hardware checkstop.",
+            "type": "boolean"
         },
 
         "docNotes":

--- a/extensions/openpower-pels/src.cpp
+++ b/extensions/openpower-pels/src.cpp
@@ -351,6 +351,11 @@ SRC::SRC(const message::Entry& regEntry, const AdditionalData& additionalData,
     setBMCPosition();
     setMotherboardCCIN(dataIface);
 
+    if (regEntry.src.checkstopFlag)
+    {
+        setErrorStatusFlag(ErrorStatusFlags::hwCheckstop);
+    }
+
     // Fill in the last 4 words from the AdditionalData property contents.
     setUserDefinedHexWords(regEntry, additionalData);
 

--- a/extensions/openpower-pels/src.hpp
+++ b/extensions/openpower-pels/src.hpp
@@ -62,8 +62,9 @@ class SRC : public Section
      * @brief Enums for the error status bits in hex word 5
      *        of BMC SRCs.
      */
-    enum class ErrorStatusFlags
+    enum class ErrorStatusFlags : uint32_t
     {
+        hwCheckstop = 0x80000000,
         terminateFwErr = 0x20000000,
         deconfigured = 0x02000000,
         guarded = 0x01000000

--- a/test/openpower-pels/registry_test.cpp
+++ b/test/openpower-pels/registry_test.cpp
@@ -84,7 +84,8 @@ const auto registryData = R"(
                         "Description": "bad voltage",
                         "AdditionalDataPropSource": "VOLTAGE"
                     }
-                }
+                },
+                "CheckstopFlag": true
             },
 
             "Documentation":
@@ -186,6 +187,7 @@ TEST_F(RegistryTest, TestFindEntry)
 
     EXPECT_EQ(entry->src.type, 0xBD);
     EXPECT_EQ(entry->src.reasonCode, 0x2333);
+    EXPECT_TRUE(entry->src.checkstopFlag);
 
     auto& hexwords = entry->src.hexwordADFields;
     EXPECT_TRUE(hexwords);
@@ -241,6 +243,7 @@ TEST_F(RegistryTest, TestFindEntryMinimal)
     EXPECT_EQ(entry->src.type, 0xBD);
     EXPECT_FALSE(entry->src.hexwordADFields);
     EXPECT_FALSE(entry->src.symptomID);
+    EXPECT_FALSE(entry->src.checkstopFlag);
 }
 
 TEST_F(RegistryTest, TestBadJSON)

--- a/test/openpower-pels/src_test.cpp
+++ b/test/openpower-pels/src_test.cpp
@@ -491,6 +491,7 @@ TEST_F(SRCTest, RegistryCalloutTest)
     message::Entry entry;
     entry.src.type = 0xBD;
     entry.src.reasonCode = 0xABCD;
+    entry.src.checkstopFlag = true;
     entry.subsystem = 0x42;
 
     entry.callouts = R"(
@@ -554,6 +555,15 @@ TEST_F(SRCTest, RegistryCalloutTest)
             .WillOnce(Return(std::vector<bool>{false, false, false}));
 
         SRC src{entry, ad, dataIface};
+
+        EXPECT_TRUE(
+            src.getErrorStatusFlag(SRC::ErrorStatusFlags::deconfigured));
+        EXPECT_TRUE(src.getErrorStatusFlag(SRC::ErrorStatusFlags::hwCheckstop));
+
+        const auto& hexwords = src.hexwordData();
+        auto mask = static_cast<uint32_t>(SRC::ErrorStatusFlags::deconfigured) |
+                    static_cast<uint32_t>(SRC::ErrorStatusFlags::hwCheckstop);
+        EXPECT_EQ(hexwords[5 - 2] & mask, mask);
 
         auto& callouts = src.callouts()->callouts();
         ASSERT_EQ(callouts.size(), 2);

--- a/test/openpower-pels/src_test.cpp
+++ b/test/openpower-pels/src_test.cpp
@@ -556,13 +556,8 @@ TEST_F(SRCTest, RegistryCalloutTest)
 
         SRC src{entry, ad, dataIface};
 
-        EXPECT_TRUE(
-            src.getErrorStatusFlag(SRC::ErrorStatusFlags::deconfigured));
-        EXPECT_TRUE(src.getErrorStatusFlag(SRC::ErrorStatusFlags::hwCheckstop));
-
         const auto& hexwords = src.hexwordData();
-        auto mask = static_cast<uint32_t>(SRC::ErrorStatusFlags::deconfigured) |
-                    static_cast<uint32_t>(SRC::ErrorStatusFlags::hwCheckstop);
+        auto mask = static_cast<uint32_t>(SRC::ErrorStatusFlags::hwCheckstop);
         EXPECT_EQ(hexwords[5 - 2] & mask, mask);
 
         auto& callouts = src.callouts()->callouts();


### PR DESCRIPTION
#### PEL: Support for CheckstopFlag msg reg field
```
Similiar to the DeconfigFlag field that was recently added, this one
indicates the PEL is for a hardware checkstop and results in a bit in
SRC hex word 5 being set.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: Ib05de7471ad3e32f48e7f20a5c611abc119fe82a
```