### PR TITLE
1020: PEL: Close SBE FFDC file descriptors

### DIFF
--- a/extensions/openpower-pels/sbe_ffdc_handler.cpp
+++ b/extensions/openpower-pels/sbe_ffdc_handler.cpp
@@ -216,7 +216,7 @@ void SbeFFDC::process(const sbeFfdcPacketType& ffdcPkt)
     ffdcFiles.push_back(pf);
 
     // save the file path to delete the file after usage.
-    paths.push_back(ffdcFile.getPath());
+    paths.emplace_back(ffdcFile.getPath(), pf.fd);
 
     // Format ffdc user data and create new file.
     std::string data;
@@ -231,7 +231,7 @@ void SbeFFDC::process(const sbeFfdcPacketType& ffdcPkt)
     pdf.fd = pelDataFile.getFd();
     ffdcFiles.push_back(pdf);
 
-    paths.push_back(pelDataFile.getPath());
+    paths.emplace_back(pelDataFile.getPath(), pdf.fd);
 }
 
 } // namespace sbe

--- a/extensions/openpower-pels/sbe_ffdc_handler.hpp
+++ b/extensions/openpower-pels/sbe_ffdc_handler.hpp
@@ -5,6 +5,8 @@
 
 #include <libekb.H>
 
+#include <filesystem>
+
 namespace openpower
 {
 namespace pels
@@ -99,17 +101,21 @@ class SbeFFDC
 
         try
         {
-            for (auto path : paths)
+            for (const auto& [path, fd] : paths)
             {
                 if (!path.empty())
                 {
                     // Delete temporary file from file system
                     std::error_code ec;
                     std::filesystem::remove(path, ec);
-                    // Clear path to indicate file has been deleted
-                    path.clear();
+                }
+
+                if (fd != -1)
+                {
+                    close(fd);
                 }
             }
+            paths.clear();
         }
         catch (...)
         {
@@ -159,10 +165,10 @@ class SbeFFDC
     void process(const sbeFfdcPacketType& ffdcPkt);
 
     /**
-     * @brief  Temporary files path information created as part of FFDC
+     * @brief  Temporary files path and FD information created as part of FFDC
      *         processing.
      */
-    std::vector<std::filesystem::path> paths;
+    std::vector<std::pair<std::filesystem::path, int>> paths;
 
     /**
      * @brief PEL FFDC files, which includes the user data sections and the


### PR DESCRIPTION
#### PEL: Close SBE FFDC file descriptors
```
The descriptors were being leaked since deleting the file doesn't close
the FD which was explicitly opened earlier.

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
Change-Id: I5d0f1ed91f38af6830ea4f3c600adc402102564c
```