### PR TITLE
1060: PEL: Add error log entries for faultlog poweron time read/write

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -861,6 +861,46 @@
         },
 
         {
+            "Name": "org.open_power.Faultlog.PoweronTime.ReadFail",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0xF100",
+
+            "SRC": {
+                "ReasonCode": "0xF101",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Failure to read chassis poweron time from persistent file",
+                "Message": "Failure to read chassis poweron time from persistent file",
+                "Notes": [
+                    "Severity needs to be set based on needs for this registry.",
+                    "Debug traces will be captured in AdditionalData section"
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.Faultlog.PoweronTime.WriteFail",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0xF100",
+
+            "SRC": {
+                "ReasonCode": "0xF102",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Failure to write chassis poweron time to persistent file",
+                "Message": "Failure to write chassis poweron time to persistent file",
+                "Notes": [
+                    "Severity needs to be set based on needs for this registry.",
+                    "Debug traces will be captured in AdditionalData section"
+                ]
+            }
+        },
+
+        {
             "Name": "org.open_power.Faultlog.Error.DeconfiguredHW",
             "Subsystem": "cec_hardware",
             "Severity": "predictive",


### PR DESCRIPTION
#### PEL: Add error log entries for faultlog poweron time read/write
```
During chassis poweron current system time is written to a persistent
file that is used to ignore old power or thermal errors as part of
faultlog dump/pel generation.

Add error log entries for failure to read/write from the persistent
file.

Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>
Change-Id: I70420b529d930fee833402d1b3276ffb1ec2a518
```