### PR TITLE
PEL: switch fmt::format to use std::format

### DIFF
--- a/extensions/openpower-pels/bcd_time.cpp
+++ b/extensions/openpower-pels/bcd_time.cpp
@@ -15,7 +15,6 @@
  */
 #include "bcd_time.hpp"
 
-#include <fmt/format.h>
 #include <time.h>
 
 #include <phosphor-logging/log.hpp>

--- a/extensions/openpower-pels/data_interface.cpp
+++ b/extensions/openpower-pels/data_interface.cpp
@@ -19,8 +19,6 @@
 
 #include "util.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/lg2.hpp>
 #include <xyz/openbmc_project/State/BMC/server.hpp>
 #include <xyz/openbmc_project/State/Boot/Progress/server.hpp>

--- a/extensions/openpower-pels/entry_points.cpp
+++ b/extensions/openpower-pels/entry_points.cpp
@@ -21,9 +21,9 @@
 #include "manager.hpp"
 #include "pldm_interface.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 namespace openpower
 {
@@ -69,7 +69,7 @@ void pelStartup(internal::Manager& logManager)
         // Log message and continue,
         // This is to help continue creating PEL in raw format.
         log<level::ERR>(
-            fmt::format("Failed to set PDBG_DTB: ({})", strerror(errno))
+            std::format("Failed to set PDBG_DTB: ({})", strerror(errno))
                 .c_str());
     }
 #endif

--- a/extensions/openpower-pels/extended_user_data.cpp
+++ b/extensions/openpower-pels/extended_user_data.cpp
@@ -19,9 +19,9 @@
 #ifdef PELTOOL
 #include "user_data_json.hpp"
 #endif
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 namespace openpower::pels
 {
@@ -35,7 +35,7 @@ void ExtendedUserData::unflatten(Stream& stream)
     if (_header.size <= SectionHeader::flattenedSize() + 4)
     {
         throw std::out_of_range(
-            fmt::format("ExtendedUserData::unflatten: SectionHeader::size {} "
+            std::format("ExtendedUserData::unflatten: SectionHeader::size {} "
                         "too small",
                         _header.size));
     }
@@ -61,7 +61,7 @@ ExtendedUserData::ExtendedUserData(Stream& pel)
     catch (const std::exception& e)
     {
         log<level::ERR>(
-            fmt::format("Cannot unflatten ExtendedUserData section: {}",
+            std::format("Cannot unflatten ExtendedUserData section: {}",
                         e.what())
                 .c_str());
         _valid = false;
@@ -90,7 +90,7 @@ void ExtendedUserData::validate()
     if (header().id != static_cast<uint16_t>(SectionID::extUserData))
     {
         log<level::ERR>(
-            fmt::format("Invalid ExtendedUserData section ID: {0:#x}",
+            std::format("Invalid ExtendedUserData section ID: {0:#x}",
                         header().id)
                 .c_str());
         _valid = false;

--- a/extensions/openpower-pels/extended_user_header.cpp
+++ b/extensions/openpower-pels/extended_user_header.cpp
@@ -19,9 +19,9 @@
 #include "pel_types.hpp"
 #include "pel_values.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 namespace openpower
 {
@@ -43,7 +43,7 @@ ExtendedUserHeader::ExtendedUserHeader(Stream& pel)
     catch (const std::exception& e)
     {
         log<level::ERR>(
-            fmt::format("Cannot unflatten extended user header: {}", e.what())
+            std::format("Cannot unflatten extended user header: {}", e.what())
                 .c_str());
         _valid = false;
     }
@@ -111,7 +111,7 @@ void ExtendedUserHeader::validate()
     if (header().id != static_cast<uint16_t>(SectionID::extendedUserHeader))
     {
         log<level::ERR>(
-            fmt::format("Invalid ExtendedUserHeader section ID: {0:#x}",
+            std::format("Invalid ExtendedUserHeader section ID: {0:#x}",
                         header().id)
                 .c_str());
         failed = true;
@@ -120,7 +120,7 @@ void ExtendedUserHeader::validate()
     if (header().version != extendedUserHeaderVersion)
     {
         log<level::ERR>(
-            fmt::format("Invalid ExtendedUserHeader version: {0:#x}",
+            std::format("Invalid ExtendedUserHeader version: {0:#x}",
                         header().version)
                 .c_str());
         failed = true;

--- a/extensions/openpower-pels/failing_mtms.cpp
+++ b/extensions/openpower-pels/failing_mtms.cpp
@@ -19,9 +19,9 @@
 #include "pel_types.hpp"
 #include "pel_values.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 namespace openpower
 {
@@ -54,7 +54,7 @@ FailingMTMS::FailingMTMS(Stream& pel)
     catch (const std::exception& e)
     {
         log<level::ERR>(
-            fmt::format("Cannot unflatten failing MTM section: {}", e.what())
+            std::format("Cannot unflatten failing MTM section: {}", e.what())
                 .c_str());
         _valid = false;
     }
@@ -67,14 +67,14 @@ void FailingMTMS::validate()
     if (header().id != static_cast<uint16_t>(SectionID::failingMTMS))
     {
         log<level::ERR>(
-            fmt::format("Invalid failing MTMS section ID: {0:#x}", header().id)
+            std::format("Invalid failing MTMS section ID: {0:#x}", header().id)
                 .c_str());
         failed = true;
     }
 
     if (header().version != failingMTMSVersion)
     {
-        log<level::ERR>(fmt::format("Invalid failing MTMS version: {0:#x}",
+        log<level::ERR>(std::format("Invalid failing MTMS version: {0:#x}",
                                     header().version)
                             .c_str());
         failed = true;

--- a/extensions/openpower-pels/fapi_data_process.cpp
+++ b/extensions/openpower-pels/fapi_data_process.cpp
@@ -6,7 +6,6 @@ extern "C"
 #include "fapi_data_process.hpp"
 
 #include <attributes_info.H>
-#include <fmt/format.h>
 #include <libphal.H>
 #include <phal_exception.H>
 
@@ -15,6 +14,7 @@ extern "C"
 #include <algorithm>
 #include <cstdlib>
 #include <cstring>
+#include <format>
 #include <iomanip>
 #include <list>
 #include <map>
@@ -120,7 +120,7 @@ int pdbgCallbackToGetTgtReqAttrsVal(struct pdbg_target* target,
     catch (const std::exception& e)
     {
         // log message and continue with default data
-        log<level::ERR>(fmt::format("getLocationCode({}): Exception({})",
+        log<level::ERR>(std::format("getLocationCode({}): Exception({})",
                                     pdbg_target_path(target), e.what())
                             .c_str());
     }
@@ -128,14 +128,14 @@ int pdbgCallbackToGetTgtReqAttrsVal(struct pdbg_target* target,
     if (DT_GET_PROP(ATTR_PHYS_DEV_PATH, target, targetInfo->physDevPath))
     {
         log<level::ERR>(
-            fmt::format("Could not read({}) PHYS_DEV_PATH attribute",
+            std::format("Could not read({}) PHYS_DEV_PATH attribute",
                         pdbg_target_path(target))
                 .c_str());
     }
 
     if (DT_GET_PROP(ATTR_MRU_ID, target, targetInfo->mruId))
     {
-        log<level::ERR>(fmt::format("Could not read({}) ATTR_MRU_ID attribute",
+        log<level::ERR>(std::format("Could not read({}) ATTR_MRU_ID attribute",
                                     pdbg_target_path(target))
                             .c_str());
     }
@@ -167,9 +167,15 @@ bool getTgtReqAttrsVal(const std::vector<uint8_t>& physBinPath,
                                    &targetInfo);
     if (ret == 0)
     {
-        log<level::ERR>(fmt::format("Given ATTR_PHYS_BIN_PATH value({:02x}) "
+        std::string fmt;
+        for (auto value : targetInfo.physBinPath)
+        {
+            fmt += std::format("{:02X} ", value);
+        }
+
+        log<level::ERR>(std::format("Given ATTR_PHYS_BIN_PATH value {} "
                                     "not found in phal device tree",
-                                    fmt::join(targetInfo.physBinPath, ""))
+                                    fmt)
                             .c_str());
         return false;
     }
@@ -202,7 +208,7 @@ static std::string getPelPriority(const std::string& phalPriority)
     auto it = priorityMap.find(phalPriority);
     if (it == priorityMap.end())
     {
-        log<level::ERR>(fmt::format("Unsupported phal priority({}) is given "
+        log<level::ERR>(std::format("Unsupported phal priority({}) is given "
                                     "to get pel priority format",
                                     phalPriority)
                             .c_str());
@@ -256,7 +262,7 @@ void processClockInfoErrorHelper(const FFDC& ffdc,
                                  FFDCData& ffdcUserData)
 {
     log<level::INFO>(
-        fmt::format("processClockInfoErrorHelper: FFDC Message[{}]",
+        std::format("processClockInfoErrorHelper: FFDC Message[{}]",
                     ffdc.message)
             .c_str());
 
@@ -470,7 +476,7 @@ void convertFAPItoPELformat(FFDC& ffdc, json& pelJSONFmtCalloutDataList,
     else if ((ffdc.ffdc_type != FFDC_TYPE_NONE) &&
              (ffdc.ffdc_type != FFDC_TYPE_UNSUPPORTED))
     {
-        log<level::ERR>(fmt::format("Unsupported phal FFDC type to create PEL. "
+        log<level::ERR>(std::format("Unsupported phal FFDC type to create PEL. "
                                     "MSG: {}",
                                     ffdc.message)
                             .c_str());

--- a/extensions/openpower-pels/fru_identity.cpp
+++ b/extensions/openpower-pels/fru_identity.cpp
@@ -17,9 +17,9 @@
 
 #include "pel_values.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 using namespace phosphor::logging;
 
@@ -256,7 +256,7 @@ void FRUIdentity::setMaintenanceProcedure(const std::string& procedure,
         else
         {
             log<level::ERR>(
-                fmt::format("Invalid maintenance procedure {}", procedure)
+                std::format("Invalid maintenance procedure {}", procedure)
                     .c_str());
             strncpy(_pnOrProcedureID.data(), "INVALID",
                     _pnOrProcedureID.size());

--- a/extensions/openpower-pels/generic.cpp
+++ b/extensions/openpower-pels/generic.cpp
@@ -15,9 +15,9 @@
  */
 #include "generic.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 namespace openpower
 {
@@ -57,7 +57,7 @@ Generic::Generic(Stream& pel)
     catch (const std::exception& e)
     {
         log<level::ERR>(
-            fmt::format("Cannot unflatten generic section: {}", e.what())
+            std::format("Cannot unflatten generic section: {}", e.what())
                 .c_str());
         _valid = false;
     }

--- a/extensions/openpower-pels/journal.cpp
+++ b/extensions/openpower-pels/journal.cpp
@@ -17,9 +17,9 @@
 
 #include "util.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 namespace openpower::pels
 {
@@ -64,7 +64,7 @@ void Journal::sync() const
     if (duration.count() > 100)
     {
         log<level::INFO>(
-            fmt::format("Journal sync took {}ms", duration.count()).c_str());
+            std::format("Journal sync took {}ms", duration.count()).c_str());
     }
 }
 

--- a/extensions/openpower-pels/manager.cpp
+++ b/extensions/openpower-pels/manager.cpp
@@ -23,7 +23,6 @@
 #include "service_indicators.hpp"
 #include "severity.hpp"
 
-#include <fmt/format.h>
 #include <sys/inotify.h>
 #include <unistd.h>
 
@@ -32,6 +31,7 @@
 #include <xyz/openbmc_project/Logging/Create/server.hpp>
 
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <locale>
 
@@ -646,7 +646,7 @@ std::string Manager::getPELJSON(uint32_t obmcLogID)
     // Throws InvalidArgument if not found
     auto pelID = getPELIdFromBMCLogId(obmcLogID);
 
-    auto cmd = fmt::format("/usr/bin/peltool -i {:#x}", pelID);
+    auto cmd = std::format("/usr/bin/peltool -i {:#x}", pelID);
 
     FILE* pipe = popen(cmd.c_str(), "r");
     if (!pipe)

--- a/extensions/openpower-pels/pel.cpp
+++ b/extensions/openpower-pels/pel.cpp
@@ -36,12 +36,12 @@
 #include "sbe_ffdc_handler.hpp"
 #endif
 
-#include <fmt/format.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
 #include <phosphor-logging/lg2.hpp>
 
+#include <format>
 #include <iostream>
 
 namespace openpower
@@ -818,7 +818,7 @@ void addIMKeyword(nlohmann::json& json, const DataInterfaceBase& dataIface)
     std::string value{};
 
     std::for_each(keyword.begin(), keyword.end(), [&](const auto& byte) {
-        value += fmt::format("{:02X}", byte);
+        value += std::format("{:02X}", byte);
     });
 
     json["System IM"] = value;

--- a/extensions/openpower-pels/phal_service_actions.cpp
+++ b/extensions/openpower-pels/phal_service_actions.cpp
@@ -1,10 +1,11 @@
 #include "phal_service_actions.hpp"
 
 #include <attributes_info.H>
-#include <fmt/format.h>
 #include <libphal.H>
 
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 namespace openpower
 {
@@ -40,7 +41,7 @@ std::optional<EntrySeverity> getEntrySeverityType(const std::string& guardType)
     else
     {
         log<level::ERR>(
-            fmt::format("GUARD: Unsupported GardType [{}] was given ",
+            std::format("GUARD: Unsupported GardType [{}] was given ",
                         "to get the hardware isolation entry severity type",
                         guardType.c_str())
                 .c_str());
@@ -106,7 +107,7 @@ void createGuardRecords(const nlohmann::json& jsonCallouts,
                 ss << " 0x" << std::hex << static_cast<int>(entityPath[a]);
             }
             std::string s = ss.str();
-            log<level::INFO>(fmt::format("GUARD :({})", s).c_str());
+            log<level::INFO>(std::format("GUARD :({})", s).c_str());
 
             // Get Guard type
             auto severity = EntrySeverity::Warning;
@@ -133,7 +134,7 @@ void createGuardRecords(const nlohmann::json& jsonCallouts,
         catch (const std::exception& e)
         {
             log<level::INFO>(
-                fmt::format("GUARD: Failed entry creation exception:({})",
+                std::format("GUARD: Failed entry creation exception:({})",
                             e.what())
                     .c_str());
         }
@@ -207,7 +208,7 @@ void createDeconfigRecords(const nlohmann::json& jsonCallouts,
         catch (const std::exception& e)
         {
             log<level::INFO>(
-                fmt::format(
+                std::format(
                     "Deconfig: Failed to create records, exception:({})",
                     e.what())
                     .c_str());

--- a/extensions/openpower-pels/private_header.cpp
+++ b/extensions/openpower-pels/private_header.cpp
@@ -20,9 +20,9 @@
 #include "pel_types.hpp"
 #include "pel_values.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 namespace openpower
 {
@@ -80,7 +80,7 @@ PrivateHeader::PrivateHeader(Stream& pel) :
     catch (const std::exception& e)
     {
         log<level::ERR>(
-            fmt::format("Cannot unflatten private header: {}", e.what())
+            std::format("Cannot unflatten private header: {}", e.what())
                 .c_str());
         _valid = false;
     }
@@ -129,7 +129,7 @@ void PrivateHeader::validate()
 
     if (header().id != static_cast<uint16_t>(SectionID::privateHeader))
     {
-        log<level::ERR>(fmt::format("Invalid private header section ID: {0:#x}",
+        log<level::ERR>(std::format("Invalid private header section ID: {0:#x}",
                                     header().id)
                             .c_str());
         failed = true;
@@ -137,7 +137,7 @@ void PrivateHeader::validate()
 
     if (header().version != privateHeaderVersion)
     {
-        log<level::ERR>(fmt::format("Invalid private header version: {0:#x}",
+        log<level::ERR>(std::format("Invalid private header version: {0:#x}",
                                     header().version)
                             .c_str());
         failed = true;
@@ -146,7 +146,7 @@ void PrivateHeader::validate()
     if (_sectionCount < minSectionCount)
     {
         log<level::ERR>(
-            fmt::format("Invalid section count in private header: {0:#x}",
+            std::format("Invalid section count in private header: {0:#x}",
                         _sectionCount)
                 .c_str());
         failed = true;

--- a/extensions/openpower-pels/sbe_ffdc_handler.cpp
+++ b/extensions/openpower-pels/sbe_ffdc_handler.cpp
@@ -25,11 +25,11 @@ extern "C"
 #include "temporary_file.hpp"
 
 #include <ekb/hwpf/fapi2/include/return_code_defs.H>
-#include <fmt/format.h>
 #include <libekb.H>
 
 #include <phosphor-logging/log.hpp>
 
+#include <format>
 #include <new>
 
 namespace openpower
@@ -62,7 +62,7 @@ SbeFFDC::SbeFFDC(const AdditionalData& aData, const PelFFDC& files) :
     catch (const std::exception& err)
     {
         log<level::ERR>(
-            fmt::format("Conversion failure errormsg({})", err.what()).c_str());
+            std::format("Conversion failure errormsg({})", err.what()).c_str());
         return;
     }
 
@@ -86,7 +86,7 @@ SbeFFDC::SbeFFDC(const AdditionalData& aData, const PelFFDC& files) :
 void SbeFFDC::parse(int fd)
 {
     log<level::INFO>(
-        fmt::format("SBE FFDC file fd:({}), parsing started", fd).c_str());
+        std::format("SBE FFDC file fd:({}), parsing started", fd).c_str());
 
     uint32_t ffdcBufOffset = 0;
     uint32_t pktCount = 0;
@@ -97,7 +97,7 @@ void SbeFFDC::parse(int fd)
     if (ffdcData.empty())
     {
         log<level::ERR>(
-            fmt::format("Empty SBE FFDC file fd:({}), skipping", fd).c_str());
+            std::format("Empty SBE FFDC file fd:({}), skipping", fd).c_str());
         return;
     }
 
@@ -110,7 +110,7 @@ void SbeFFDC::parse(int fd)
         auto lenWords = ntohs(ffdc->lengthinWords);
         auto fapiRc = ntohl(ffdc->fapiRc);
 
-        auto msg = fmt::format("FFDC magic: {} length in words:{} Fapirc:{}",
+        auto msg = std::format("FFDC magic: {} length in words:{} Fapirc:{}",
                                magicBytes, lenWords, fapiRc);
         log<level::INFO>(msg.c_str());
 
@@ -157,7 +157,7 @@ void SbeFFDC::parse(int fd)
     }
     if (pktCount == sbeMaxFfdcPackets)
     {
-        log<level::ERR>(fmt::format("Received more than the limit of ({})"
+        log<level::ERR>(std::format("Received more than the limit of ({})"
                                     " FFDC packets, processing only ({})",
                                     sbeMaxFfdcPackets, pktCount)
                             .c_str());

--- a/extensions/openpower-pels/service_indicators.cpp
+++ b/extensions/openpower-pels/service_indicators.cpp
@@ -15,11 +15,10 @@
  */
 #include "service_indicators.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
 
 #include <bitset>
+#include <format>
 
 namespace openpower::pels::service_indicators
 {
@@ -96,7 +95,7 @@ void LightPath::activate(const PEL& pel)
         catch (const std::exception& e)
         {
             log<level::ERR>(
-                fmt::format("Failed to assert platform SAI LED group: {}",
+                std::format("Failed to assert platform SAI LED group: {}",
                             e.what())
                     .c_str());
         }
@@ -215,7 +214,7 @@ std::vector<std::string> LightPath::getInventoryPaths(
         }
         catch (const std::exception& e)
         {
-            log<level::ERR>(fmt::format("Could not get inventory path for "
+            log<level::ERR>(std::format("Could not get inventory path for "
                                         "location code {} ({}).",
                                         locCode, e.what())
                                 .c_str());
@@ -242,7 +241,7 @@ void LightPath::setNotFunctional(
         catch (const std::exception& e)
         {
             log<level::INFO>(
-                fmt::format("Could not write Functional property on {} ({})",
+                std::format("Could not write Functional property on {} ({})",
                             path, e.what())
                     .c_str());
         }
@@ -261,7 +260,7 @@ void LightPath::createCriticalAssociation(
         catch (const std::exception& e)
         {
             log<level::INFO>(
-                fmt::format(
+                std::format(
                     "Could not set critical association on object path {} ({})",
                     path, e.what())
                     .c_str());

--- a/extensions/openpower-pels/src.cpp
+++ b/extensions/openpower-pels/src.cpp
@@ -26,9 +26,9 @@
 
 #include <sstream>
 #endif
-#include <fmt/format.h>
-
 #include <phosphor-logging/lg2.hpp>
+
+#include <format>
 
 namespace openpower
 {
@@ -967,7 +967,7 @@ std::vector<message::RegistryCallout>
         }
         catch (const std::exception& e)
         {
-            addDebugData(fmt::format(
+            addDebugData(std::format(
                 "Error parsing PEL message registry callout JSON: {}",
                 e.what()));
         }
@@ -1059,7 +1059,7 @@ void SRC::addRegistryCallout(
             catch (const std::exception& e)
             {
                 addDebugData(
-                    fmt::format("Could not get location code for {}: {}",
+                    std::format("Could not get location code for {}: {}",
                                 *trustedSymbolicFRUInvPath, e.what()));
                 locCode.clear();
             }
@@ -1196,7 +1196,7 @@ void SRC::addDevicePathCallouts(const AdditionalData& additionalData,
         }
         catch (const std::exception& e)
         {
-            auto msg = fmt::format("Unable to expand location code {}: {}",
+            auto msg = std::format("Unable to expand location code {}: {}",
                                    callout.locationCode, e.what());
             addDebugData(msg);
         }
@@ -1259,7 +1259,7 @@ void SRC::addJSONCallouts(const nlohmann::json& jsonCallouts,
         }
         catch (const std::exception& e)
         {
-            addDebugData(fmt::format(
+            addDebugData(std::format(
                 "Failed extracting callout data from JSON: {}", e.what()));
         }
     }
@@ -1284,7 +1284,7 @@ void SRC::addJSONCallout(const nlohmann::json& jsonCallout,
         }
         catch (const std::exception& e)
         {
-            addDebugData(fmt::format("Unable to expand location code {}: {}",
+            addDebugData(std::format("Unable to expand location code {}: {}",
                                      unexpandedLocCode, e.what()));
             // Use the value from the JSON so at least there's something
             locCode = unexpandedLocCode;
@@ -1356,7 +1356,7 @@ void SRC::addJSONCallout(const nlohmann::json& jsonCallout,
             catch (const std::exception& e)
             {
                 throw std::runtime_error{
-                    fmt::format("Unable to get inventory path from "
+                    std::format("Unable to get inventory path from "
                                 "location code: {}: {}",
                                 unexpandedLocCode, e.what())};
             }
@@ -1421,7 +1421,7 @@ CalloutPriority SRC::getPriorityFromJSON(const nlohmann::json& json)
     if (priorityIt == pv::calloutPriorityValues.end())
     {
         throw std::runtime_error{
-            fmt::format("Invalid priority '{}' found in JSON callout", p)};
+            std::format("Invalid priority '{}' found in JSON callout", p)};
     }
 
     return priority;
@@ -1457,7 +1457,7 @@ std::vector<src::MRU::MRUCallout>
         }
         catch (const std::exception& e)
         {
-            addDebugData(fmt::format("Invalid MRU entry in JSON: {}: {}",
+            addDebugData(std::format("Invalid MRU entry in JSON: {}: {}",
                                      mruCallout.dump(), e.what()));
         }
     }

--- a/extensions/openpower-pels/user_data.cpp
+++ b/extensions/openpower-pels/user_data.cpp
@@ -22,9 +22,9 @@
 #include "user_data_json.hpp"
 #endif
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
+
+#include <format>
 
 namespace openpower
 {
@@ -64,7 +64,7 @@ UserData::UserData(Stream& pel)
     catch (const std::exception& e)
     {
         log<level::ERR>(
-            fmt::format("Cannot unflatten user data: {}", e.what()).c_str());
+            std::format("Cannot unflatten user data: {}", e.what()).c_str());
         _valid = false;
     }
 }
@@ -88,7 +88,7 @@ void UserData::validate()
     if (header().id != static_cast<uint16_t>(SectionID::userData))
     {
         log<level::ERR>(
-            fmt::format("Invalid UserData section ID: {0:#x}", header().id)
+            std::format("Invalid UserData section ID: {0:#x}", header().id)
                 .c_str());
         _valid = false;
     }

--- a/extensions/openpower-pels/user_header.cpp
+++ b/extensions/openpower-pels/user_header.cpp
@@ -20,10 +20,9 @@
 #include "pel_values.hpp"
 #include "severity.hpp"
 
-#include <fmt/format.h>
-
 #include <phosphor-logging/log.hpp>
 
+#include <format>
 #include <iostream>
 
 namespace openpower
@@ -71,7 +70,7 @@ UserHeader::UserHeader(const message::Entry& entry,
         if (subsystemString == "invalid")
         {
             log<level::WARNING>(
-                fmt::format(
+                std::format(
                     "UH: Invalid SubSystem value in PEL_SUBSYSTEM: {:#X}",
                     eventSubsystem)
                     .c_str());
@@ -230,7 +229,7 @@ UserHeader::UserHeader(Stream& pel)
     catch (const std::exception& e)
     {
         log<level::ERR>(
-            fmt::format("Cannot unflatten user header: {}", e.what()).c_str());
+            std::format("Cannot unflatten user header: {}", e.what()).c_str());
         _valid = false;
     }
 }
@@ -241,7 +240,7 @@ void UserHeader::validate()
     if (header().id != static_cast<uint16_t>(SectionID::userHeader))
     {
         log<level::ERR>(
-            fmt::format("Invalid user header section ID: {0:#x}", header().id)
+            std::format("Invalid user header section ID: {0:#x}", header().id)
                 .c_str());
         failed = true;
     }
@@ -249,7 +248,7 @@ void UserHeader::validate()
     if (header().version != userHeaderVersion)
     {
         log<level::ERR>(
-            fmt::format("Invalid user header version: {0:#x}", header().version)
+            std::format("Invalid user header version: {0:#x}", header().version)
                 .c_str());
         failed = true;
     }


### PR DESCRIPTION
fmt::format is supported in the c++ std. This will
    help to remove fmt package dependency.

Change-Id: I89f0a5b67bbfe54168a20e93c989a1ae87f54503