### PR TITLE
Audit Log: Implement phosphor-auditlog D-Bus interface

### DIFF
--- a/dist/busconfig/phosphor-auditlog-config.conf
+++ b/dist/busconfig/phosphor-auditlog-config.conf
@@ -1,0 +1,8 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy group="root">
+    <allow own="xyz.openbmc_project.Logging.AuditLog"/>
+    <allow send_destination="xyz.openbmc_project.Logging.AuditLog"/>
+  </policy>
+</busconfig>

--- a/dist/meson.build
+++ b/dist/meson.build
@@ -3,13 +3,15 @@ systemd_system_unit_dir = dependency('systemd').get_variable(
 
 install_data(
     ['xyz.openbmc_project.Logging.service',
-     'xyz.openbmc_project.Syslog.Config.service'],
+     'xyz.openbmc_project.Syslog.Config.service',
+     'xyz.openbmc_project.Logging.AuditLog.service'],
     install_dir: systemd_system_unit_dir,
 )
 
 install_data(
     'busconfig/phosphor-logging.conf',
     'busconfig/phosphor-rsyslog-config.conf',
+    'busconfig/phosphor-auditlog-config.conf',
     install_dir: get_option('datadir') / 'dbus-1' / 'system.d',
 )
 

--- a/dist/xyz.openbmc_project.Logging.AuditLog.service
+++ b/dist/xyz.openbmc_project.Logging.AuditLog.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Audit Log Services
+
+[Service]
+ExecStart=/usr/bin/phosphor-auditlog
+Restart=always
+Type=dbus
+BusName=xyz.openbmc_project.Logging.AuditLog
+
+[Install]
+WantedBy=multi-user.target

--- a/meson.build
+++ b/meson.build
@@ -115,6 +115,7 @@ log_manager_ext_args = []
 
 subdir('extensions')
 subdir('phosphor-rsyslog-config')
+subdir('phosphor-auditlog')
 
 # Generate daemon.
 log_manager_sources = [

--- a/phosphor-auditlog/alog_manager.cpp
+++ b/phosphor-auditlog/alog_manager.cpp
@@ -1,0 +1,110 @@
+#include "alog_manager.hpp"
+
+#include "alog_parser.hpp"
+#include "alog_utils.hpp"
+
+#include <fcntl.h>
+#include <libaudit.h>
+
+#include <phosphor-logging/lg2.hpp>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/source/event.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+
+#include <cstring>
+#include <string>
+
+namespace phosphor::auditlog
+{
+
+sdbusplus::message::unix_fd ALManager::getAuditLog()
+{
+#ifdef AUDITLOG_KEEP_JSONFILE
+    ALParseFile parsedFile("/tmp/auditLog.json");
+#else
+    ALParseFile parsedFile;
+#endif
+
+    // Initialize to parse full audit log
+    ALParseAll auditParser(parsedFile);
+
+    lg2::debug("Method GetAuditLog: {FILEPATH}", "FILEPATH",
+               parsedFile.getPath());
+
+    // Parse all the events
+    auditParser.doParse();
+
+    /* Get file descriptor to return.
+     * openParseFD() throws an error if it fails to open the file.
+     */
+    auto fd = openParseFD(parsedFile);
+
+    /* Schedule the fd to be closed by sdbusplus when it sends it back over
+     * D-Bus.
+     */
+    sdeventplus::Event event = sdeventplus::Event::get_default();
+    fdCloseEventSource = std::make_unique<sdeventplus::source::Defer>(
+        event, std::bind(&ALManager::closeFD, this, fd, std::placeholders::_1));
+
+    return fd;
+}
+
+sdbusplus::message::unix_fd ALManager::getLatestEntries(uint32_t maxEvents)
+{
+#ifdef AUDITLOG_KEEP_JSONFILE
+    ALParseFile parsedFile("/tmp/auditEntries.json");
+#else
+    ALParseFile parsedFile;
+#endif
+
+    lg2::debug("Method GetLatestEntries: {FILE} maxEvents: {MAXCOUNT}", "FILE",
+               parsedFile.getPath(), "MAXCOUNT", maxEvents);
+
+    ALParseLatest auditParser(maxEvents, parsedFile);
+
+    // Parse events up to maxEvents specified
+    auditParser.doParse();
+
+    /* Get file descriptor to return.
+     * openParseFD() throws an error if it fails to open the file.
+     */
+    auto fd = openParseFD(parsedFile);
+
+    /* Schedule the fd to be closed by sdbusplus when it sends it back over
+     * D-Bus.
+     */
+    sdeventplus::Event event = sdeventplus::Event::get_default();
+    fdCloseEventSource = std::make_unique<sdeventplus::source::Defer>(
+        event, std::bind(&ALManager::closeFD, this, fd, std::placeholders::_1));
+
+    return fd;
+}
+
+int ALManager::openParseFD(const ALParseFile& parsedFile)
+{
+    // Confirm parsed file exists
+    int fd = -1;
+    std::error_code ec;
+
+    fd = open(parsedFile.getPath().c_str(), O_RDONLY | O_NONBLOCK);
+    if (fd == -1)
+    {
+        auto e = errno;
+        lg2::error("Failed to open {PATH}: {ERRNO}", "ERRNO", e, "PATH",
+                   parsedFile.getPath());
+        throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+    }
+
+    lg2::debug("Opening parsedFile: {PARSEFD}", "PARSEFD", fd);
+
+    return fd;
+}
+
+void ALManager::closeFD(int fd, sdeventplus::source::EventBase& /*source*/)
+{
+    lg2::debug("Closing parsedFile: {FD}", "FD", fd);
+    close(fd);
+    fdCloseEventSource.reset();
+}
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/alog_manager.hpp
+++ b/phosphor-auditlog/alog_manager.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "alog_utils.hpp"
+
+#include <libaudit.h>
+
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/source/event.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+#include <xyz/openbmc_project/Logging/AuditLog/server.hpp>
+
+#include <string>
+
+namespace phosphor::auditlog
+{
+
+using ALIface = sdbusplus::xyz::openbmc_project::Logging::server::AuditLog;
+using ALObject = sdbusplus::server::object_t<ALIface>;
+
+/** @class ALManager
+ *  @brief Configuration for AuditLog server
+ *  @details A concrete implementation of the
+ *  xyz.openbmc_project.Logging.AuditLog API, in order to
+ *  provide audit log support.
+ */
+class ALManager : public ALObject
+{
+  public:
+    ALManager() = delete;
+    ALManager(const ALManager&) = delete;
+    ALManager& operator=(const ALManager&) = delete;
+    ALManager(ALManager&&) = delete;
+    ALManager& operator=(ALManager&&) = delete;
+    ~ALManager() = default;
+
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] path - Path to attach at.
+     */
+    ALManager(sdbusplus::bus_t& bus, const std::string& path) :
+        ALObject(bus, path.c_str()){};
+
+    /**
+     * @brief Parses all audit log events into JSON format.
+     * @details Entries are sorted oldest to newest.
+     * @return unix_fd A read-only file descriptor to the parsed file.
+     */
+    sdbusplus::message::unix_fd getAuditLog() override;
+
+    /**
+     * @brief Parses subset of audit log events into JSON format.
+     * @details Entries are sorted newest to oldest.
+     * @param[in] maxCount - The maximum number of entries to return. Minimum
+     *            value of 1.
+     * @return unix_fd A read-only file descriptor to the parsed file.
+     */
+    sdbusplus::message::unix_fd getLatestEntries(uint32_t maxCount) override;
+
+  private:
+    /**
+     * @brief Opens previously created file in read-only mode.
+     * @param[in] parsedFile - Path to file to open
+     * @return int A file descriptor to the opened file.
+     */
+    int openParseFD(const ALParseFile& parsedFile);
+
+    /**
+     * @brief The event source for closing the file descriptor after it
+     *        has been returned from the getAuditLog or getLatestEntries
+     *        D-Bus method.
+     * @details This is shared for multiple methods. The Defer action is called
+     * before the event loop processes another event so there should not be any
+     * collisions between the multiple uses.
+     */
+    std::unique_ptr<sdeventplus::source::Defer> fdCloseEventSource;
+
+    /**
+     * @brief Closes the file descriptor passed in.
+     * @details This is called from the event loop to close FDs returned from
+     * getAuditLog() or getLatestEntries()
+     * @param[in] fd - The file descriptor to close
+     * @param[in] source - The event source object used
+     */
+    void closeFD(int fd, sdeventplus::source::EventBase& source);
+};
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/alog_parser.cpp
+++ b/phosphor-auditlog/alog_parser.cpp
@@ -1,0 +1,425 @@
+#include "alog_parser.hpp"
+
+#include "alog_manager.hpp"
+
+#include <auparse.h>
+#include <libaudit.h>
+
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+#include <cstring>
+#include <filesystem>
+#include <format>
+#include <list>
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace phosphor::auditlog
+{
+
+bool ALParser::getNextEvent()
+{
+    bool haveEvent = false;
+    int rc;
+
+    rc = auparse_next_event(au);
+    switch (rc)
+    {
+        case 1:
+            /* Success, pointing to next event */
+            haveEvent = true;
+            break;
+        case 0:
+            /* No more events */
+            haveEvent = false;
+            break;
+        case -1:
+        default:
+            /* Failure */
+            lg2::error("Failed to parse next event");
+            haveEvent = false;
+            break;
+    }
+
+    return haveEvent;
+}
+
+void ALParser::parseEvent()
+{
+    unsigned int nRecords = auparse_get_num_records(au);
+
+    // The event itself is a record. It may be the only one.
+    parseRecord();
+
+    /* Handle any additional records for this event */
+    for (unsigned int iter = 1; iter < nRecords; iter++)
+    {
+        auto rc = auparse_next_record(au);
+
+        switch (rc)
+        {
+            case 1:
+            {
+                /* Success finding record, parse it! */
+                parseRecord();
+            }
+            break;
+            case 0:
+                /* No more records, something is confused! */
+                lg2::error(
+                    "Record count ({NRECS}) and records out of sync ({ITER})",
+                    "NRECS", nRecords, "ITER", iter);
+                throw sdbusplus::xyz::openbmc_project::Common::Error::
+                    InternalFailure();
+
+                break;
+            case -1:
+            default:
+                /* Error */
+                lg2::error("Failed on record: {ITER}", "ITER", iter);
+                throw sdbusplus::xyz::openbmc_project::Common::Error::
+                    InternalFailure();
+                break;
+        }
+    }
+}
+
+void ALParser::fillAuditEntry(nlohmann::json& parsedEntry)
+{
+    parsedEntry["MessageId"] = "OpenBMC.0.5.AuditLogEntry";
+
+    /* MessageArgs: msg */
+    auto recMsg = auparse_get_record_text(au);
+    auto messageArgs = nlohmann::json::array({recMsg});
+
+    parsedEntry["MessageArgs"] = std::move(messageArgs);
+}
+
+/**
+ * @brief Strips '"' from beginning and end of value field
+ */
+inline std::string_view getValue(std::string_view fieldText)
+{
+    if (fieldText.starts_with('\"'))
+    {
+        auto endQuote = fieldText.find('\"', 1);
+
+        if (endQuote != std::string::npos)
+        {
+            return fieldText.substr(1, endQuote - 1);
+        }
+    }
+
+    return fieldText;
+}
+
+void ALParser::fillUsysEntry(nlohmann::json& parsedEntry)
+{
+    parsedEntry["MessageId"] = "OpenBMC.0.5.AuditLogUsysConfig";
+
+    nlohmann::json messageArgs = nlohmann::json::array();
+
+    /* Map expected fields to MessageArgs index.
+     * Audit records contain fields not returned for admin use. E.g. the pid of
+     * the auditd daemon that recorded the entry is part of the record.
+     */
+    std::map<std::string, int>::const_iterator mapEntry;
+    const std::map<std::string, int> msgArgMap({{"type", 0},
+                                                {"op", 1},
+                                                {"acct", 2},
+                                                {"exe", 3},
+                                                {"hostname", 4},
+                                                {"addr", 5},
+                                                {"terminal", 6},
+                                                {"res", 7}});
+
+    /* Walk the fields and insert mapped fields into messageArgs */
+    int fieldIdx = 0;
+    size_t nFields = 0; // Used to confirm all expected fields found
+    do
+    {
+        fieldIdx++;
+
+        // Can return nullptr
+        const char* fieldName = auparse_get_field_name(au);
+        std::string_view fieldTxt = auparse_get_field_str(au);
+
+        if ((fieldName == nullptr) || (fieldTxt.empty()))
+        {
+            lg2::debug("Unexpected field:{FIELDIDX}", "FIELDIDX", fieldIdx);
+            continue;
+        }
+
+        /* Map the field to the message arg, not all fields are args */
+        mapEntry = msgArgMap.find(fieldName);
+        if (mapEntry != msgArgMap.end())
+        {
+            /* Remove '"' from fieldTxt */
+            messageArgs[mapEntry->second] = getValue(fieldTxt);
+            nFields++;
+#ifdef AUDITLOG_FULL_DEBUG
+            lg2::debug(
+                "Field {NFIELD} : {FIELDNAME} = {FIELDSTR} argIdx = {ARGIDX}",
+                "NFIELD", fieldIdx, "FIELDNAME", fieldName, "FIELDSTR",
+                fieldTxt.c_str(), "ARGIDX", mapEntry->second);
+#endif // AUDITLOG_FULL_DEBUG
+        }
+    } while (auparse_next_field(au) == 1);
+
+    /* Error handling, make sure all the fields we care about
+     * exist. If any are missing set to null string.
+     */
+    if (nFields != msgArgMap.size())
+    {
+#ifdef AUDITLOG_FULL_DEBUG
+        lg2::debug("Incorrect nFields = {NFIELDS}", "NFIELDS", nFields);
+#endif // AUDITLOG_FULL_DEBUG
+
+        // Set missing fields to empty string
+        size_t argIdx;
+        for (argIdx = 0;
+             (nFields != msgArgMap.size()) && (argIdx < msgArgMap.size());
+             argIdx++)
+        {
+            if (messageArgs[argIdx] == nullptr)
+            {
+#ifdef AUDITLOG_FULL_DEBUG
+                lg2::debug("Correcting arg={ARGIDX}", "ARGIDX", argIdx);
+#endif // AUDITLOG_FULL_DEBUG
+                messageArgs[argIdx] = "";
+                nFields++;
+            }
+        }
+
+#ifdef AUDITLOG_FULL_DEBUG
+        lg2::debug("nFields = {NFIELDS}", "NFIELDS", nFields);
+#endif // AUDITLOG_FULL_DEBUG
+    }
+
+    parsedEntry["MessageArgs"] = std::move(messageArgs);
+}
+
+bool ALParser::formatMsgReg(nlohmann::json& parsedEntry)
+{
+    /* Fill common fields for any record type */
+    auto fullTimestamp = auparse_get_timestamp(au);
+    if (fullTimestamp == nullptr)
+    {
+        lg2::error("Failed to parse timestamp");
+        throw sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure();
+    }
+    parsedEntry["EventTimestamp"] = fullTimestamp->sec;
+    parsedEntry["ID"] = std::format("{}.{}:{}", fullTimestamp->sec,
+                                    fullTimestamp->milli,
+                                    fullTimestamp->serial);
+
+    /* Fill varied args fields based on record type */
+    int recType = auparse_get_type(au);
+
+    switch (recType)
+    {
+        case AUDIT_USYS_CONFIG:
+            fillUsysEntry(parsedEntry);
+            break;
+
+        default:
+            fillAuditEntry(parsedEntry);
+            break;
+    }
+
+#ifdef AUDITLOG_FULL_DEBUG
+    lg2::debug("parsedEntry = {PARSEDENTRY}", "PARSEDENTRY",
+               parsedEntry.dump());
+#endif // AUDITLOG_FULL_DEBUG
+
+    return true;
+}
+
+bool ALParser::formatGeneral(nlohmann::json& parsedEntry)
+{
+    auto fullTimestamp = auparse_get_timestamp(au);
+    if (fullTimestamp == nullptr)
+    {
+        lg2::error("Failed to parse timestamp");
+        throw sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure();
+    }
+    parsedEntry["EventTimestamp"] = fullTimestamp->sec;
+    parsedEntry["ID"] = std::format("{}.{}:{}", fullTimestamp->sec,
+                                    fullTimestamp->milli,
+                                    fullTimestamp->serial);
+
+    auto recMsg = auparse_get_record_text(au);
+    parsedEntry["Event"] = recMsg;
+
+#ifdef AUDITLOG_FULL_DEBUG
+    lg2::debug("parsedEntry = {PARSEDENTRY}", "PARSEDENTRY",
+               parsedEntry.dump());
+#endif // AUDITLOG_FULL_DEBUG
+
+    return true;
+}
+
+bool ALParser::formatRaw(nlohmann::json& parsedEntry)
+{
+    auto recMsg = auparse_get_record_text(au);
+    parsedEntry["Event"] = recMsg;
+
+#ifdef AUDITLOG_FULL_DEBUG
+    lg2::debug("parsedEntry = {PARSEDENTRY}", "PARSEDENTRY",
+               parsedEntry.dump());
+#endif // AUDITLOG_FULL_DEBUG
+
+    return true;
+}
+
+void ALParser::parseRecord()
+{
+    nlohmann::json parsedEntry;
+
+    if (formatEntry(parsedEntry))
+    {
+        // Dump JSON object to parsedStream
+        parsedStream << parsedEntry.dump() << '\n';
+    }
+
+    return;
+}
+
+bool ALParser::openParsedFile(const std::string& filePath)
+{
+    std::error_code ec;
+
+    /* Expect the file has already been created */
+    if (!std::filesystem::exists(filePath, ec))
+    {
+        lg2::error("File {FILE} doesn't already exist.", "FILE", filePath);
+        return false;
+    }
+
+    // Create/Open file using truncate
+    parsedStream.open(filePath, std::ios::out);
+    if (parsedStream.fail())
+    {
+        lg2::error("Failed to open {FILE}", "FILE", filePath);
+        throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+    }
+
+    return true;
+}
+
+void ALParser::processEvents()
+{
+    // Loop over all the events
+    while (getNextEvent())
+    {
+        parseEvent();
+    }
+}
+
+void ALParser::doParse()
+{
+    lg2::debug("Parsing All");
+    processEvents();
+}
+
+void ALParseLatest::parseRecord()
+{
+    nlohmann::json parsedEntry;
+
+    if (formatEntry(parsedEntry))
+    {
+        // Keep list limited to maxLeftCount
+        if (parsedEntries.size() >= maxLeftCount)
+        {
+            parsedEntries.pop_back();
+        }
+
+        parsedEntries.emplace_front(parsedEntry.dump());
+    }
+
+    return;
+}
+
+size_t ALParseLatest::writeParsedEntries()
+{
+    /* Add newest events to the file */
+    for (const auto& iter : parsedEntries)
+    {
+        parsedStream << iter << '\n';
+    }
+
+    auto parsedCount = parsedEntries.size();
+    parsedEntries.clear();
+
+    lg2::debug("maxLeftCount: {MAXCOUNT} parsedCount: {PARSED}", "MAXCOUNT",
+               maxLeftCount, "PARSED", parsedCount);
+
+    return parsedCount;
+}
+
+void ALParseLatest::doParse()
+{
+    lg2::debug("Parsing maxCount: {MAXCOUNT}", "MAXCOUNT", maxCount);
+    if (maxCount > 0)
+    {
+        processEvents();
+
+        auto parsedCount = writeParsedEntries();
+
+        // Process next file if needed to reach desired # entries
+        while (parsedCount < maxLeftCount)
+        {
+            maxLeftCount -= parsedCount;
+
+            if (!initNextLog())
+            {
+                // No more files to parse
+                break;
+            }
+
+            processEvents();
+
+            /* Add newest events to the file */
+            parsedCount = writeParsedEntries();
+        }
+    }
+}
+
+bool ALParseLatest::initNextLog()
+{
+    if (au != nullptr)
+    {
+        lg2::debug("initNextLog: destroying existing au");
+        auparse_destroy(au);
+        au = nullptr;
+    }
+
+    /* Determine path of next log file to process.
+     * Newest file has no extension and matches 0 index value.
+     */
+    std::string logFilePath = "/var/log/audit/audit.log";
+
+    if (logFileIdx)
+    {
+        logFilePath = std::format("/var/log/audit/audit.log.{}",
+                                  std::to_string(logFileIdx));
+    }
+
+    lg2::debug("initNextLog: Initialize for {FILE}", "FILE", logFilePath);
+    au = auparse_init(AUSOURCE_FILE, logFilePath.c_str());
+
+    if (au != nullptr)
+    {
+        logFileIdx++;
+        return true;
+    }
+
+    // No more files to process
+    return false;
+}
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/alog_parser.hpp
+++ b/phosphor-auditlog/alog_parser.hpp
@@ -1,0 +1,256 @@
+#pragma once
+
+#include "alog_utils.hpp"
+
+#include <auparse.h>
+#include <libaudit.h>
+
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+#include <xyz/openbmc_project/Logging/AuditLog/server.hpp>
+
+#include <fstream>
+#include <list>
+#include <string>
+
+namespace phosphor::auditlog
+{
+
+/** @class ALParser
+ *  @brief Parsing audit log using auparse library services
+ *  @details Provides abstraction to auparse library services
+ */
+class ALParser
+{
+  public:
+    ALParser(const ALParser&) = delete;
+    ALParser& operator=(const ALParser&) = delete;
+    ALParser(ALParser&&) = delete;
+    ALParser& operator=(ALParser&&) = delete;
+
+    /** @brief Constructor to initialize parsing of audit log files
+     *  @details Prepares parsedFile for writing of audit events
+     *  @param[in] parsedFile Initialized file for holding parsed log events
+     */
+    explicit ALParser(ALParseFile& parsedFile)
+    {
+        if (!openParsedFile(parsedFile.getPath()))
+        {
+            throw sdbusplus::xyz::openbmc_project::Common::File::Error::Write();
+        }
+    }
+
+    ~ALParser()
+    {
+        auparse_destroy(au);
+    }
+
+    /**
+     * @brief Process audit events from initialized au source
+     */
+    virtual void doParse();
+
+    /**
+     * @brief Process audit events from initialized au source
+     */
+    void processEvents();
+
+  protected:
+    /**
+     * @brief Format audit entries into raw JSON
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    virtual bool formatEntry(nlohmann::json& parsedEntry)
+    {
+        return formatRaw(parsedEntry);
+    };
+
+    /**
+     * @brief Formats next record into JSON format using message registry
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatMsgReg(nlohmann::json& parsedEntry);
+
+    /**
+     * @brief Formats next record into JSON general format
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatGeneral(nlohmann::json& parsedEntry);
+
+    /**
+     * @brief Formats next record into JSON raw format
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatRaw(nlohmann::json& parsedEntry);
+
+    auparse_state_t* au = nullptr;
+    std::ofstream parsedStream;
+
+  private:
+    /**
+     * @brief Moves parser to point to next event
+     *
+     * @return false when no more events exist, or on error
+     */
+    bool getNextEvent();
+
+    /**
+     * @brief Parses next event and each of its records into JSON format
+     * @details Writes the audit log events to parsedStream.
+     */
+    void parseEvent();
+
+    /**
+     * @brief Parses and writes next record into JSON format
+     */
+    virtual void parseRecord();
+
+    /**
+     * @brief Parses general audit entry into JSON format
+     * @details Used with audit entries without specific handling. Text of audit
+     * log message is written as-is.
+     */
+    void fillAuditEntry(nlohmann::json& parsedEntry);
+
+    /**
+     * @brief Parses AUDIT_USYS_CONFIG audit entry into JSON format
+     * @details Expected fields from audit log entry are split into MessageArgs
+     */
+    void fillUsysEntry(nlohmann::json& parsedEntry);
+
+    /**
+     * @brief Opens and truncates specified file
+     * @param[in] filePath Path of file to open. File should exist.
+     * @return bool True if stream was established to file, false otherwise.
+     */
+    bool openParsedFile(const std::string& filePath);
+};
+
+/** @class ALParseLatest
+ *  @brief Parsing audit log using auparse library services
+ *  @details Provides means to parse only latest entries
+ */
+class ALParseLatest : public ALParser
+{
+  public:
+    ALParseLatest(const ALParseLatest&) = delete;
+    ALParseLatest& operator=(const ALParseLatest&) = delete;
+    ALParseLatest(ALParseLatest&&) = delete;
+    ALParseLatest& operator=(ALParseLatest&&) = delete;
+
+    /** @brief Constructor to initialize parsing of audit log files
+     *  @param[in] maxEvents Maximum number of events to return.
+     *  @param[in] parsedFile Initialized file for holding parsed log events
+     */
+    ALParseLatest(uint32_t maxEvents, ALParseFile& parsedFile) :
+        ALParser(parsedFile)
+    {
+        lg2::debug("Constructing ALParseLatest: {MAXCOUNT}", "MAXCOUNT",
+                   maxEvents);
+
+        initNextLog();
+        maxCount = maxEvents;
+        maxLeftCount = maxEvents;
+
+        if (au == nullptr)
+        {
+            lg2::error("Failed to init auparse");
+            throw sdbusplus::xyz::openbmc_project::Common::Error::
+                InternalFailure();
+        }
+    }
+
+    /**
+     * @brief Process audit events from initialized au source
+     * @details Limits number of entries written to maxCount.
+     */
+    void doParse() override;
+
+  protected:
+    /**
+     * @brief Format audit entries into JSON using message registry form
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatEntry(nlohmann::json& parsedEntry) override
+    {
+        return formatMsgReg(parsedEntry);
+    };
+
+  private:
+    size_t maxCount = 0;
+    size_t maxLeftCount = 0;
+    unsigned int logFileIdx = 0;
+    std::list<std::string> parsedEntries;
+
+    /**
+     * @brief Parses next record into JSON format and adds to list
+     */
+    void parseRecord() override;
+
+    /**
+     * @brief Initializes parser to next audit log available
+     * @details Initializes with the latest audit log first. Each subsequent
+     *         call will initialize with the next oldest audit log file until
+     *         a file cannot be found.
+     * @return bool True if initialization succeeded, false otherwise.
+     */
+    bool initNextLog();
+
+    /**
+     * @brief Writes parsedEntries to parsedStream
+     * @details parsedEntries is cleared after entries are written.
+     * @return size_t Number of entries written.
+     */
+    size_t writeParsedEntries();
+};
+
+/** @class ALParseAll
+ *  @brief Parsing audit log using auparse library services
+ *  @details Provides means to parse all entries
+ */
+class ALParseAll : public ALParser
+{
+  public:
+    ALParseAll(const ALParseAll&) = delete;
+    ALParseAll& operator=(const ALParseAll&) = delete;
+    ALParseAll(ALParseAll&&) = delete;
+    ALParseAll& operator=(ALParseAll&&) = delete;
+
+    /** @brief Constructor to initialize parsing of audit log files
+     *  @details Initializes au to parse all audit logs.
+     *  @param[in] parsedFile Initialized file for holding parsed log events
+     */
+    explicit ALParseAll(ALParseFile& parsedFile) : ALParser(parsedFile)
+    {
+        lg2::debug("Constructing ALParseAll");
+        au = auparse_init(AUSOURCE_LOGS, nullptr);
+        if (au == nullptr)
+        {
+            lg2::error("Failed to init auparse");
+            throw sdbusplus::xyz::openbmc_project::Common::Error::
+                InternalFailure();
+        }
+    }
+
+  protected:
+    /**
+     * @brief Format audit entries into general JSON
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatEntry(nlohmann::json& parsedEntry) override
+    {
+        return formatGeneral(parsedEntry);
+    };
+};
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/alog_utils.hpp
+++ b/phosphor-auditlog/alog_utils.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <libaudit.h>
+
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace phosphor::auditlog
+{
+
+/** @class ALParseFile
+ *  @brief Creation of temporary file for parsed audit log
+ */
+class ALParseFile
+{
+  public:
+    ALParseFile(const ALParseFile&) = delete;
+    ALParseFile& operator=(const ALParseFile&) = delete;
+    ALParseFile(ALParseFile&&) = delete;
+    ALParseFile& operator=(ALParseFile&&) = delete;
+
+    ~ALParseFile()
+    {
+        if (!pathName.empty() && !keepFile)
+        {
+            lg2::debug("Removing {FILE}", "FILE", pathName);
+            std::filesystem::remove(pathName);
+        }
+    }
+
+    /** @brief Create empty temporary file
+     */
+    ALParseFile()
+    {
+        std::string tempFile = std::filesystem::temp_directory_path() /
+                               "auditLogJson-XXXXXX";
+
+        lg2::debug("Constructing ALParseFile template={NAME}", "NAME",
+                   tempFile);
+
+        int fd = mkstemp(tempFile.data());
+        if (fd == -1)
+        {
+            throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+        }
+
+        // Store path to temporary file
+        pathName = tempFile;
+
+        // Close file descriptor
+        if (close(fd) == -1)
+        {
+            // Delete temporary file.  The destructor won't be called because
+            // the exception below causes this constructor to exit without
+            // completing.
+            std::filesystem::remove(pathName);
+            throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+        }
+    }
+
+    /** @brief Create parsed file that is not removed on destruction
+     *  @details Used for debug only
+     *  @param[in] filePath Path to file to be created. File will be truncated
+     *             if it exists.
+     */
+    explicit ALParseFile(const std::string& filePath)
+    {
+        std::ofstream parsedStream;
+        std::error_code ec;
+
+        // Create/Open file using trunc
+        parsedStream.open(filePath, std::ios::trunc);
+        if (parsedStream.fail())
+        {
+            lg2::error("Failed to open {FILE}", "FILE", filePath);
+            throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+        }
+
+        // Set permissions on file created to match audit.log, 600
+        std::filesystem::perms permission = std::filesystem::perms::owner_read |
+                                            std::filesystem::perms::owner_write;
+        std::filesystem::permissions(filePath, permission);
+
+        pathName = filePath;
+        keepFile = true;
+    }
+
+    /**
+     * @brief Return path of file
+     */
+    const std::string& getPath() const
+    {
+        return pathName;
+    }
+
+  private:
+    std::string pathName;
+    bool keepFile = false; // Don't remove file on destruction
+};
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/main.cpp
+++ b/phosphor-auditlog/main.cpp
@@ -1,0 +1,32 @@
+#include "config.h"
+
+#include "config_main.h"
+
+#include "alog_manager.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/manager.hpp>
+
+// AUDITLOG_PATH
+constexpr auto auditLogMgrRoot = "/xyz/openbmc_project/logging/auditlog";
+// AUDITLOG_INTERFACE
+constexpr auto auditLogBusName = "xyz.openbmc_project.Logging.AuditLog";
+
+int main(int /*argc*/, char* /*argv*/[])
+{
+    auto bus = sdbusplus::bus::new_default();
+    auto event = sdeventplus::Event::get_default();
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+
+    sdbusplus::server::manager_t objManager{bus, auditLogMgrRoot};
+
+    // Reserve the dbus service name
+    bus.request_name(auditLogBusName);
+
+    phosphor::auditlog::ALManager alMgr(bus, auditLogMgrRoot);
+
+    // Handle dbus processing forever.
+    event.loop();
+
+    return 0;
+}

--- a/phosphor-auditlog/meson.build
+++ b/phosphor-auditlog/meson.build
@@ -1,0 +1,34 @@
+auditd_dep = dependency('audit')
+ausparse_dep = dependency('auparse', required: true)
+
+auditlog_sources = [
+        files(
+        'main.cpp',
+        'alog_manager.cpp',
+        'alog_parser.cpp',
+        )
+]
+
+extra_args = []
+
+# Add for in-depth debug, too much for normal use
+# extra_args += ['-DAUDITLOG_FULL_DEBUG',]
+
+# Add to keep JSON file around on exit of method
+# extra_args += ['-DAUDITLOG_KEEP_JSONFILE',]
+
+executable('phosphor-auditlog',
+    auditlog_sources,
+    include_directories: include_directories('..'),
+    cpp_args: extra_args,
+    dependencies: [
+        conf_h_dep,
+        phosphor_logging_dep,
+        pdi_dep,
+        sdbusplus_dep,
+        sdeventplus_dep,
+        auditd_dep,
+        ausparse_dep,
+    ],
+    install: true,
+)


### PR DESCRIPTION
Scaled down implementation of upstream design still under review [1].
This implements scaled down downstream PDI interface [2].

```
$ busctl tree xyz.openbmc_project.Logging.AuditLog
`- /xyz
  `- /xyz/openbmc_project
    `- /xyz/openbmc_project/logging
      `- /xyz/openbmc_project/logging/auditlog

$ busctl introspect xyz.openbmc_project.Logging.AuditLog /xyz/openbmc_project/logging/auditlog
NAME                                 TYPE      SIGNATURE  RESULT/VALUE  FLAGS
org.freedesktop.DBus.Introspectable  interface -          -             -
.Introspect                          method    -          s             -
org.freedesktop.DBus.ObjectManager   interface -          -             -
.GetManagedObjects                   method    -          a{oa{sa{sv}}} -
.InterfacesAdded                     signal    oa{sa{sv}} -             -
.InterfacesRemoved                   signal    oas        -             -
org.freedesktop.DBus.Peer            interface -          -             -
.GetMachineId                        method    -          s             -
.Ping                                method    -          -             -
org.freedesktop.DBus.Properties      interface -          -             -
.Get                                 method    ss         v             -
.GetAll                              method    s          a{sv}         -
.Set                                 method    ssv        -             -
.PropertiesChanged                   signal    sa{sv}as   -             -
xyz.openbmc_project.Logging.AuditLog interface -          -             -
.GetAuditLog                         method    -          h             -
.GetLatestEntries                    method    u          h             -

/* Tested with option to not remove JSON file in order to see results */
$ busctl call xyz.openbmc_project.Logging.AuditLog /xyz/openbmc_project/logging/auditlog xyz.openbmc_project.Logging.AuditLog GetAuditLog

$ busctl call xyz.openbmc_project.Logging.AuditLog /xyz/openbmc_project/logging/auditlog xyz.openbmc_project.Logging.AuditLog GetLatestEntries u 10

$ busctl call xyz.openbmc_project.Logging.AuditLog
/xyz/openbmc_project/logging/auditlog
xyz.openbmc_project.Logging.AuditLog GetLatestEntries u 1000

/* Entry count of 0 returns an empty file */
$ busctl call xyz.openbmc_project.Logging.AuditLog /xyz/openbmc_project/logging/auditlog xyz.openbmc_project.Logging.AuditLog GetLatestEntries u 0
```

[1] https://gerrit.openbmc.org/c/openbmc/docs/+/63915
[2] https://github.com/ibm-openbmc/phosphor-dbus-interfaces/pull/95