### PR TITLE
PEL: Change asprintf call to snprintf

### DIFF
--- a/extensions/openpower-pels/json_utils.hpp
+++ b/extensions/openpower-pels/json_utils.hpp
@@ -2,6 +2,7 @@
 
 #include <ctype.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <cstdint>
 #include <fstream>
@@ -67,12 +68,13 @@ void jsonInsertArray(std::string& jsonStr, const std::string& fieldName,
 template <typename T>
 std::string getNumberString(const char* format, T number)
 {
-    char* value = nullptr;
+    constexpr size_t valueSize = 100;
+    char value[valueSize];
     std::string numString;
 
     static_assert(std::is_integral<T>::value, "Integral required.");
 
-    int len = asprintf(&value, format, number);
+    int len = snprintf(value, valueSize, format, number);
     if (len >= 0)
     {
         numString = value;
@@ -82,7 +84,6 @@ std::string getNumberString(const char* format, T number)
         throw std::invalid_argument(
             std::string("getNumberString: invalid format string: ") + format);
     }
-    free(value);
 
     return numString;
 }


### PR DESCRIPTION
A static analysis security scanner (HCL AppScan SAST) flagged the asprintf call as a vulnerability because the format string is passed in.

While really it isn't an issue because the format string is always hardcoded in the calling function and isn't input by a user, this commit changes it anyway to get it off the list.

Use snprintf instead.  While it still takes a passed in format string, a hardcoded maximum length is used so that the scanner shouldn't flag it as a possible buffer overrun.


Change-Id: Ife309b63470536940ac88c27d13fe73716096326