### PR TITLE
Fixup OCC error names and add LogsCleared informational PEL

### DIFF
--- a/extensions/openpower-pels/meson.build
+++ b/extensions/openpower-pels/meson.build
@@ -3,11 +3,7 @@ libpldm_dep = dependency(
     default_options: ['oem-ibm=enabled'],
 )
 
-if cpp.has_header('nlohmann/json.hpp')
-    nlohmann_json_dep = declare_dependency()
-else
-    nlohmann_json_dep = dependency('nlohmann-json')
-endif
+nlohmann_json_dep = dependency('nlohmann_json', include_type: 'system')
 
 python_inst = import('python').find_installation('python3')
 python_ver = python_inst.language_version()

--- a/extensions/openpower-pels/meson.build
+++ b/extensions/openpower-pels/meson.build
@@ -19,7 +19,7 @@ extra_sources = []
 extra_dependencies = []
 extra_args = []
 
-build_phal = get_option('phal').enabled()
+build_phal = get_option('phal').allowed()
 
 if build_phal
     extra_sources += [

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -480,6 +480,40 @@
         },
 
         {
+            "Name": "xyz.openbmc_project.Logging.Error.LogsCleared",
+            "Subsystem": "bmc_firmware",
+            "Severity": "non_error",
+
+            "SRC": {
+                "ReasonCode": "0x2007",
+                "Words6To9": {
+                    "6": {
+                        "Description": "Number of logs deleted",
+                        "AdditionalDataPropSource": "NUM_LOGS"
+                    }
+                }
+            },
+
+            "Documentation": {
+                "Description": "All event logs were deleted",
+                "Message": "All event logs were deleted",
+                "Notes": [
+                    "This is an informational error noting that ",
+                    "someone deleted all of the event logs."
+                ]
+            },
+
+            "JournalCapture": {
+                "Sections": [
+                    {
+                        "SyslogID": "systemd",
+                        "NumLines": 10
+                    }
+                ]
+            }
+        },
+
+        {
             "Name": "org.open_power.PHAL.Error.Boot",
             "Subsystem": "cec_hardware",
             "ComponentID": "0x3000",

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -804,7 +804,7 @@
         },
 
         {
-            "Name": "org.open_power.OCC.Firmware.PresenceMismatch",
+            "Name": "org.open_power.OCC.Firmware.Error.PresenceMismatch",
             "Subsystem": "bmc_firmware",
             "ComponentID": "0x2600",
             "Severity": "predictive",
@@ -833,7 +833,7 @@
         },
 
         {
-            "Name": "org.open_power.OCC.Device.SafeState",
+            "Name": "org.open_power.OCC.Device.Error.SafeState",
             "Subsystem": "processor_chip",
             "ComponentID": "0x2600",
             "Severity": "non_error",
@@ -854,7 +854,7 @@
         },
 
         {
-            "Name": "org.open_power.OCC.Device.ReadFailure",
+            "Name": "org.open_power.OCC.Device.Error.ReadFailure",
             "Subsystem": "cec_chip_iface",
             "ComponentID": "0x2600",
             "Severity": "predictive",
@@ -870,6 +870,26 @@
                 "Notes": [
                     "The BMC failed to communicate with the OCC and retried three times.",
                     "The BMC requests that the OCC reset."
+                ]
+            }
+        },
+
+        {
+            "Name": "org.open_power.OCC.Device.Error.OpenFailure",
+            "Subsystem": "cec_chip_iface",
+            "ComponentID": "0x2600",
+            "Severity": "predictive",
+
+            "SRC": {
+                "ReasonCode": "0x2684",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "OCC communication failure",
+                "Message": "BMC failed to communicate with the OCC",
+                "Notes": [
+                    "There was a failure trying to open an OCC device driver file"
                 ]
             }
         },

--- a/gen/xyz/openbmc_project/Logging/meson.build
+++ b/gen/xyz/openbmc_project/Logging/meson.build
@@ -1,2 +1,16 @@
 # Generated file; do not modify.
+generated_sources += custom_target(
+    'xyz/openbmc_project/Logging__cpp'.underscorify(),
+    input: [ '../../../../yaml/xyz/openbmc_project/Logging.errors.yaml',  ],
+    output: [ 'error.cpp', 'error.hpp',  ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'cpp',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../../yaml',
+        'xyz/openbmc_project/Logging',
+    ],
+)
+
 subdir('Internal')

--- a/gen/xyz/openbmc_project/meson.build
+++ b/gen/xyz/openbmc_project/meson.build
@@ -1,2 +1,16 @@
 # Generated file; do not modify.
 subdir('Logging')
+generated_others += custom_target(
+    'xyz/openbmc_project/Logging__markdown'.underscorify(),
+    input: [ '../../../yaml/xyz/openbmc_project/Logging.errors.yaml',  ],
+    output: [ 'Logging.md' ],
+    depend_files: sdbusplusplus_depfiles,
+    command: [
+        sdbuspp_gen_meson_prog, '--command', 'markdown',
+        '--output', meson.current_build_dir(),
+        '--tool', sdbusplusplus_prog,
+        '--directory', meson.current_source_dir() / '../../../yaml',
+        'xyz/openbmc_project/Logging',
+    ],
+)
+

--- a/log_manager.hpp
+++ b/log_manager.hpp
@@ -6,6 +6,7 @@
 #include "xyz/openbmc_project/Logging/Create/server.hpp"
 #include "xyz/openbmc_project/Logging/Entry/server.hpp"
 #include "xyz/openbmc_project/Logging/Internal/Manager/server.hpp"
+#include "xyz/openbmc_project/Logging/error.hpp"
 
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/bus.hpp>
@@ -23,6 +24,10 @@ extern const std::map<std::string, level> g_errLevelMap;
 using CreateIface = sdbusplus::xyz::openbmc_project::Logging::server::Create;
 using DeleteAllIface =
     sdbusplus::xyz::openbmc_project::Collection::server::DeleteAll;
+
+using Severity = sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level;
+using LogsCleared =
+    sdbusplus::xyz::openbmc_project::Logging::Error::LogsCleared;
 
 namespace details
 {
@@ -109,9 +114,11 @@ class Manager : public details::ServerObject<details::ManagerIface>
 
     /** @brief  Erase all error log entries
      *
+     *  @return size_t - count of erased entries
      */
-    void eraseAll()
+    size_t eraseAll()
     {
+        size_t entriesSize = entries.size();
         auto iter = entries.begin();
         while (iter != entries.end())
         {
@@ -120,6 +127,8 @@ class Manager : public details::ServerObject<details::ManagerIface>
             erase(e);
         }
         entryId = 0;
+
+        return entriesSize;
     }
 
     /** @brief Returns the count of high severity errors
@@ -182,10 +191,8 @@ class Manager : public details::ServerObject<details::ManagerIface>
      * @param[in] severity - level of the error
      * @param[in] additionalData - The AdditionalData property for the error
      */
-    void create(
-        const std::string& message,
-        sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level severity,
-        const std::map<std::string, std::string>& additionalData);
+    void create(const std::string& message, Severity severity,
+                const std::map<std::string, std::string>& additionalData);
 
     /** @brief Creates an event log, and accepts FFDC files
      *
@@ -201,11 +208,10 @@ class Manager : public details::ServerObject<details::ManagerIface>
      * @param[in] additionalData - The AdditionalData property for the error
      * @param[in] ffdc - A vector of FFDC file info
      */
-    void createWithFFDC(
-        const std::string& message,
-        sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level severity,
-        const std::map<std::string, std::string>& additionalData,
-        const FFDCEntries& ffdc);
+    void
+        createWithFFDC(const std::string& message, Severity severity,
+                       const std::map<std::string, std::string>& additionalData,
+                       const FFDCEntries& ffdc);
 
     /** @brief Common wrapper for creating an Entry object
      *
@@ -369,7 +375,11 @@ class Manager : public details::ServerObject<DeleteAllIface, CreateIface>
     void deleteAll() override
     {
         log<level::INFO>("Deleting all log entries");
-        manager.eraseAll();
+        auto numbersOfLogs = manager.eraseAll();
+        std::map<std::string, std::string> additionalData;
+        additionalData.emplace("NUM_LOGS", std::to_string(numbersOfLogs));
+        manager.create(LogsCleared::errName, Severity::Informational,
+                       additionalData);
     }
 
     /** @brief D-Bus method call implementation to create an event log.
@@ -379,10 +389,8 @@ class Manager : public details::ServerObject<DeleteAllIface, CreateIface>
      * @param[in] severity - Level of the error
      * @param[in] additionalData - The AdditionalData property for the error
      */
-    void create(
-        std::string message,
-        sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level severity,
-        std::map<std::string, std::string> additionalData) override
+    void create(std::string message, Severity severity,
+                std::map<std::string, std::string> additionalData) override
     {
         manager.create(message, severity, additionalData);
     }
@@ -398,8 +406,7 @@ class Manager : public details::ServerObject<DeleteAllIface, CreateIface>
      * @param[in] ffdc - A vector of FFDC file info
      */
     void createWithFFDCFiles(
-        std::string message,
-        sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level severity,
+        std::string message, Severity severity,
         std::map<std::string, std::string> additionalData,
         std::vector<std::tuple<CreateIface::FFDCFormat, uint8_t, uint8_t,
                                sdbusplus::message::unix_fd>>

--- a/subprojects/nlohmann-json.wrap
+++ b/subprojects/nlohmann-json.wrap
@@ -1,6 +1,0 @@
-[wrap-git]
-url = https://github.com/nlohmann/json
-revision = HEAD
-
-[provide]
-nlohmann-json = nlohmann_json_dep

--- a/subprojects/nlohmann_json.wrap
+++ b/subprojects/nlohmann_json.wrap
@@ -1,0 +1,6 @@
+[wrap-git]
+revision = HEAD
+url = https://github.com/nlohmann/json.git
+
+[provide]
+nlohmann_json = nlohmann_json_dep

--- a/test/meson.build
+++ b/test/meson.build
@@ -24,8 +24,6 @@ if not get_option('openpower-pel-extension').disabled()
 endif
 
 tests = [
-    'elog_quiesce_test',
-    'elog_update_ts_test',
     'extensions_test',
     'remote_logging_test_address',
     'remote_logging_test_config',
@@ -33,7 +31,6 @@ tests = [
     'sdtest',
     'serialization_test_path',
     'serialization_test_properties',
-    'elog_errorwrap_test',
 ]
 foreach t : tests
     test(
@@ -52,5 +49,32 @@ foreach t : tests
             ],
             include_directories: include_directories('..', '../gen'),
         )
+    )
+endforeach
+
+tests_non_parallel = [
+    'elog_quiesce_test',
+    'elog_update_ts_test',
+    'elog_errorwrap_test',
+]
+
+foreach t : tests_non_parallel
+    test(
+        'test_' + t.underscorify(),
+        executable(
+            'test-' + t.underscorify(),
+            t + '.cpp',
+            'common.cpp',
+            log_manager_sources,
+            '../phosphor-rsyslog-config/server-conf.cpp',
+            dependencies: [
+                gmock_dep,
+                gtest_dep,
+                log_manager_deps,
+                phosphor_logging_dep,
+            ],
+            include_directories: include_directories('..', '../gen'),
+        ),
+        is_parallel: false,
     )
 endforeach

--- a/yaml/xyz/openbmc_project/Logging.errors.yaml
+++ b/yaml/xyz/openbmc_project/Logging.errors.yaml
@@ -1,0 +1,3 @@
+# xyz.openbmc_project.Logging.Error
+- name: LogsCleared
+  description: Indicate the user cleared all the logs

--- a/yaml/xyz/openbmc_project/Logging.metadata.yaml
+++ b/yaml/xyz/openbmc_project/Logging.metadata.yaml
@@ -1,0 +1,5 @@
+- name: LogsCleared
+  level: INFO
+  meta:
+      - str: "NUM_LOGS=%u"
+        type: size_t


### PR DESCRIPTION
The community added code to create an informational event log when all event logs are deleted.  This is what we did on FSP, so pulling it in here too.

Also pulling in the commits to fixup the OCC error names so they match what is being created.

https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/68609