### PR TITLE
Use raw procedure names in PEL message registry.

### DIFF
--- a/extensions/openpower-pels/registry/README.md
+++ b/extensions/openpower-pels/registry/README.md
@@ -329,6 +329,17 @@ callouts in the registry.
 
 There is room for up to 10 callouts in a PEL.
 
+Available maintenance procedures are listed [here][1] and in the source code
+[here][2].
+
+[1]:
+  https://github.com/ibm-openbmc/openpower-pel-parsers/blob/master/modules/calloutparsers/ocallouts/ocallouts.py
+[2]:
+  https://github.com/openbmc/phosphor-logging/blob/master/extensions/openpower-pels/pel_values.cpp
+
+If a procedure is needed that doesn't exist yet, please contact the owner of
+this code for instructions.
+
 #### Callouts example based on the system type
 
 ```json
@@ -353,7 +364,7 @@ There is room for up to 10 callouts in a PEL.
         [
             {
                 "Priority": "high",
-                "Procedure": "SVCDOCS"
+                "Procedure": "BMC0002"
             }
         ]
 
@@ -364,7 +375,7 @@ There is room for up to 10 callouts in a PEL.
 
 The above example shows that on system 'system1', the FRU at location P1-C1 will
 be called out with a priority of high, and the FRU at P1 with a priority of low.
-On every other system, the maintenance procedure SVCDOCS is called out.
+On every other system, the maintenance procedure BMC0002 is called out.
 
 #### Callouts example based on an AdditionalData field
 

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -237,7 +237,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -267,7 +267,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -412,7 +412,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -454,7 +454,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" },
+                        { "Priority": "high", "Procedure": "BMC0001" },
                         { "Priority": "medium", "SymbolicFRU": "service_docs" }
                     ]
                 }
@@ -478,7 +478,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -704,7 +704,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -802,7 +802,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -855,7 +855,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "medium", "Procedure": "bmc_code" }
+                        { "Priority": "medium", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -995,7 +995,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "detected_issue_need_service"
+                            "Procedure": "BMC0008"
                         }
                     ]
                 }
@@ -1050,7 +1050,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1102,7 +1102,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1137,7 +1137,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1167,7 +1167,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1201,7 +1201,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1235,7 +1235,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1269,7 +1269,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1303,7 +1303,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1337,7 +1337,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1371,7 +1371,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1405,7 +1405,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1439,7 +1439,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1472,7 +1472,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1556,7 +1556,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -2233,7 +2233,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "power_overcurrent" }
+                        { "Priority": "high", "Procedure": "BMC0005" }
                     ]
                 }
             ],
@@ -2331,7 +2331,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "power_overcurrent" }
+                        { "Priority": "high", "Procedure": "BMC0005" }
                     ]
                 }
             ],
@@ -4247,7 +4247,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -4277,7 +4277,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -4457,7 +4457,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -4536,7 +4536,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5451,7 +5451,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5483,7 +5483,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "system_vpd_correction"
+                            "Procedure": "BMC0007"
                         }
                     ]
                 }
@@ -5512,7 +5512,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5568,7 +5568,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5599,7 +5599,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "system_vpd_correction"
+                            "Procedure": "BMC0007"
                         }
                     ]
                 }
@@ -5690,7 +5690,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "bmc_code"
+                            "Procedure": "BMC0001"
                         }
                     ]
                 }
@@ -5718,7 +5718,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "bmc_code"
+                            "Procedure": "BMC0001"
                         }
                     ]
                 }
@@ -5788,7 +5788,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5811,7 +5811,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5835,7 +5835,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5858,7 +5858,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5881,7 +5881,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5904,7 +5904,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5927,7 +5927,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5950,7 +5950,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5973,7 +5973,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6005,7 +6005,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6032,7 +6032,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6054,7 +6054,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6075,7 +6075,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6096,7 +6096,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "medium", "Procedure": "bmc_code" }
+                        { "Priority": "medium", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6117,7 +6117,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6138,7 +6138,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6159,7 +6159,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6180,7 +6180,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6201,7 +6201,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6222,7 +6222,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "medium", "Procedure": "bmc_code" }
+                        { "Priority": "medium", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6243,7 +6243,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6264,7 +6264,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6285,7 +6285,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6306,7 +6306,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6327,7 +6327,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6348,7 +6348,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6370,7 +6370,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6391,7 +6391,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6412,7 +6412,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6433,7 +6433,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6454,7 +6454,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6475,7 +6475,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6496,7 +6496,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6517,7 +6517,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -280,6 +280,78 @@
         },
 
         {
+            "Name": "xyz.openbmc_project.Common.File.Error.Open",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x1000",
+            "SRC": {
+                "ReasonCode": "0x100D",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Failed to open a file",
+                "Message": "Failed to open a file",
+                "Notes": ["The file name is in a UserData section."]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.File.Error.Read",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x1000",
+            "SRC": {
+                "ReasonCode": "0x100E",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Failed to read a file",
+                "Message": "Failed to read a file",
+                "Notes": ["The file name is in a UserData section."]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.File.Error.Seek",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x1000",
+            "SRC": {
+                "ReasonCode": "0x100F",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Failed to seek in a file",
+                "Message": "Failed to seek in a file",
+                "Notes": ["The file name is in a UserData section."]
+            }
+        },
+
+        {
             "Name": "org.open_power.Logging.Error.SentBadPELToHost",
             "Subsystem": "bmc_firmware",
             "Severity": "non_error",

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -291,7 +291,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -315,7 +315,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -339,7 +339,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],

--- a/extensions/openpower-pels/registry/schema/registry_example.json
+++ b/extensions/openpower-pels/registry/schema/registry_example.json
@@ -50,7 +50,7 @@
                                 "CalloutList": [
                                     {
                                         "Priority": "high",
-                                        "Procedure": "bmc_code"
+                                        "Procedure": "BMC0001"
                                     }
                                 ]
                             }

--- a/extensions/openpower-pels/registry/schema/schema.json
+++ b/extensions/openpower-pels/registry/schema/schema.json
@@ -534,18 +534,8 @@
         },
 
         "procedure": {
-            "description": "The maintenance procedure callout.",
-            "type": "string",
-            "enum": [
-                "bmc_code",
-                "next_level_support",
-                "sbe_code",
-                "fsi_path",
-                "power_overcurrent",
-                "find_sue_root_cause",
-                "system_vpd_correction",
-                "detected_issue_need_service"
-            ]
+            "description": "The maintenance procedure callout. List of available procedures is at https://github.com/ibm-openbmc/openpower-pel-parsers/blob/master/modules/calloutparsers/ocallouts/ocallouts.py ",
+            "type": "string"
         },
 
         "useInventoryLocCode": {

--- a/extensions/openpower-pels/src.cpp
+++ b/extensions/openpower-pels/src.cpp
@@ -1036,8 +1036,8 @@ void SRC::addRegistryCallout(
     if (!regCallout.procedure.empty())
     {
         // Procedure callout
-        callout = std::make_unique<src::Callout>(priority,
-                                                 regCallout.procedure);
+        callout = std::make_unique<src::Callout>(priority, regCallout.procedure,
+                                                 src::CalloutValueType::raw);
     }
     else if (!regCallout.symbolicFRU.empty())
     {

--- a/test/openpower-pels/pel_manager_test.cpp
+++ b/test/openpower-pels/pel_manager_test.cpp
@@ -243,7 +243,7 @@ TEST_F(ManagerTest, TestCreateWithMessageRegistry)
             "Callouts": [
                 {
                     "CalloutList": [
-                        {"Priority": "high", "Procedure": "bmc_code"},
+                        {"Priority": "high", "Procedure": "BMC0001"},
                         {"Priority": "medium", "SymbolicFRU": "service_docs"}
                     ]
                 }

--- a/test/openpower-pels/registry_test.cpp
+++ b/test/openpower-pels/registry_test.cpp
@@ -458,7 +458,7 @@ TEST_F(RegistryTest, TestGetCallouts)
             [
                 {
                     "Priority": "medium",
-                    "Procedure": "bmc_code"
+                    "Procedure": "BMC0001"
                 },
                 {
                     "Priority": "low",
@@ -503,7 +503,7 @@ TEST_F(RegistryTest, TestGetCallouts)
         EXPECT_EQ(callouts.size(), 2);
         EXPECT_EQ(callouts[0].priority, "medium");
         EXPECT_EQ(callouts[0].locCode, "");
-        EXPECT_EQ(callouts[0].procedure, "bmc_code");
+        EXPECT_EQ(callouts[0].procedure, "BMC0001");
         EXPECT_EQ(callouts[0].symbolicFRU, "");
         EXPECT_EQ(callouts[1].priority, "low");
         EXPECT_EQ(callouts[1].locCode, "P3-C8");
@@ -616,7 +616,7 @@ TEST_F(RegistryTest, TestGetCallouts)
                                 },
                                 {
                                     "Priority": "low",
-                                    "Procedure": "bmc_code",
+                                    "Procedure": "BMC0001",
                                     "CalloutType": "config_procedure"
                                 }
                             ]
@@ -671,7 +671,7 @@ TEST_F(RegistryTest, TestGetCallouts)
             EXPECT_EQ(callouts[1].symbolicFRUTrusted, "");
             EXPECT_EQ(callouts[2].priority, "low");
             EXPECT_EQ(callouts[2].locCode, "");
-            EXPECT_EQ(callouts[2].procedure, "bmc_code");
+            EXPECT_EQ(callouts[2].procedure, "BMC0001");
             EXPECT_EQ(callouts[2].symbolicFRU, "");
             EXPECT_EQ(callouts[2].symbolicFRUTrusted, "");
 

--- a/test/openpower-pels/src_test.cpp
+++ b/test/openpower-pels/src_test.cpp
@@ -478,7 +478,7 @@ TEST_F(SRCTest, RegistryCalloutTest)
                 },
                 {
                     "Priority": "medium",
-                    "Procedure": "bmc_code"
+                    "Procedure": "BMC0001"
                 }
             ]
         },


### PR DESCRIPTION
Use the actual names so that the script that creates IBM's documentation (RCDL files) can pull them in, so that they will show up with the SRCs on IBM's web site.

The other commit is to add some missing SRCs.