### PR TITLE
Use raw procedure names in PEL message registry

### DIFF
--- a/extensions/openpower-pels/registry/README.md
+++ b/extensions/openpower-pels/registry/README.md
@@ -329,6 +329,17 @@ callouts in the registry.
 
 There is room for up to 10 callouts in a PEL.
 
+Available maintenance procedures are listed [here][1] and in the source code
+[here][2].
+
+[1]:
+  https://github.com/ibm-openbmc/openpower-pel-parsers/blob/master/modules/calloutparsers/ocallouts/ocallouts.py
+[2]:
+  https://github.com/openbmc/phosphor-logging/blob/master/extensions/openpower-pels/pel_values.cpp
+
+If a procedure is needed that doesn't exist yet, please contact the owner of
+this code for instructions.
+
 #### Callouts example based on the system type
 
 ```json
@@ -353,7 +364,7 @@ There is room for up to 10 callouts in a PEL.
         [
             {
                 "Priority": "high",
-                "Procedure": "SVCDOCS"
+                "Procedure": "BMC0002"
             }
         ]
 
@@ -364,7 +375,7 @@ There is room for up to 10 callouts in a PEL.
 
 The above example shows that on system 'system1', the FRU at location P1-C1 will
 be called out with a priority of high, and the FRU at P1 with a priority of low.
-On every other system, the maintenance procedure SVCDOCS is called out.
+On every other system, the maintenance procedure BMC0002 is called out.
 
 #### Callouts example based on an AdditionalData field
 

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -280,6 +280,78 @@
         },
 
         {
+            "Name": "xyz.openbmc_project.Common.File.Error.Open",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x1000",
+            "SRC": {
+                "ReasonCode": "0x100D",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Failed to open a file",
+                "Message": "Failed to open a file",
+                "Notes": ["The file name is in a UserData section."]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.File.Error.Read",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x1000",
+            "SRC": {
+                "ReasonCode": "0x100E",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Failed to read a file",
+                "Message": "Failed to read a file",
+                "Notes": ["The file name is in a UserData section."]
+            }
+        },
+
+        {
+            "Name": "xyz.openbmc_project.Common.File.Error.Seek",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x1000",
+            "SRC": {
+                "ReasonCode": "0x100F",
+                "Words6To9": {}
+            },
+
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "bmc_code" }
+                    ]
+                }
+            ],
+
+            "Documentation": {
+                "Description": "Failed to seek in a file",
+                "Message": "Failed to seek in a file",
+                "Notes": ["The file name is in a UserData section."]
+            }
+        },
+
+        {
             "Name": "org.open_power.Logging.Error.SentBadPELToHost",
             "Subsystem": "bmc_firmware",
             "Severity": "non_error",

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -237,7 +237,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -267,7 +267,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -412,7 +412,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -454,7 +454,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" },
+                        { "Priority": "high", "Procedure": "BMC0001" },
                         { "Priority": "medium", "SymbolicFRU": "service_docs" }
                     ]
                 }
@@ -478,7 +478,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -738,7 +738,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -836,7 +836,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -889,7 +889,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "medium", "Procedure": "bmc_code" }
+                        { "Priority": "medium", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -1049,7 +1049,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "detected_issue_need_service"
+                            "Procedure": "BMC0008"
                         }
                     ]
                 }
@@ -1104,7 +1104,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1156,7 +1156,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1191,7 +1191,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1221,7 +1221,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1255,7 +1255,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1289,7 +1289,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1323,7 +1323,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1357,7 +1357,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1391,7 +1391,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1425,7 +1425,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1459,7 +1459,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1493,7 +1493,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1526,7 +1526,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -1610,7 +1610,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }
@@ -2287,7 +2287,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "power_overcurrent" }
+                        { "Priority": "high", "Procedure": "BMC0005" }
                     ]
                 }
             ],
@@ -2385,7 +2385,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "power_overcurrent" }
+                        { "Priority": "high", "Procedure": "BMC0005" }
                     ]
                 }
             ],
@@ -4294,7 +4294,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -4324,7 +4324,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -4504,7 +4504,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -4583,7 +4583,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5498,7 +5498,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5530,7 +5530,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "system_vpd_correction"
+                            "Procedure": "BMC0007"
                         }
                     ]
                 }
@@ -5559,7 +5559,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5615,7 +5615,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5646,7 +5646,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "system_vpd_correction"
+                            "Procedure": "BMC0007"
                         }
                     ]
                 }
@@ -5737,7 +5737,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "bmc_code"
+                            "Procedure": "BMC0001"
                         }
                     ]
                 }
@@ -5765,7 +5765,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "bmc_code"
+                            "Procedure": "BMC0001"
                         }
                     ]
                 }
@@ -5837,7 +5837,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5863,7 +5863,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5886,7 +5886,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5910,7 +5910,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5933,7 +5933,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5956,7 +5956,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -5979,7 +5979,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6002,7 +6002,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6025,7 +6025,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6048,7 +6048,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6080,7 +6080,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6107,7 +6107,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6129,7 +6129,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6150,7 +6150,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6171,7 +6171,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "medium", "Procedure": "bmc_code" }
+                        { "Priority": "medium", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6192,7 +6192,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6213,7 +6213,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6234,7 +6234,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6255,7 +6255,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6276,7 +6276,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6297,7 +6297,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "medium", "Procedure": "bmc_code" }
+                        { "Priority": "medium", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6318,7 +6318,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6339,7 +6339,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6360,7 +6360,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6381,7 +6381,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6402,7 +6402,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6423,7 +6423,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6445,7 +6445,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6466,7 +6466,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6487,7 +6487,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6508,7 +6508,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6529,7 +6529,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6550,7 +6550,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6571,7 +6571,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -6592,7 +6592,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -291,7 +291,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -315,7 +315,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],
@@ -339,7 +339,7 @@
             "Callouts": [
                 {
                     "CalloutList": [
-                        { "Priority": "high", "Procedure": "bmc_code" }
+                        { "Priority": "high", "Procedure": "BMC0001" }
                     ]
                 }
             ],

--- a/extensions/openpower-pels/registry/schema/registry_example.json
+++ b/extensions/openpower-pels/registry/schema/registry_example.json
@@ -50,7 +50,7 @@
                                 "CalloutList": [
                                     {
                                         "Priority": "high",
-                                        "Procedure": "bmc_code"
+                                        "Procedure": "BMC0001"
                                     }
                                 ]
                             }

--- a/extensions/openpower-pels/registry/schema/schema.json
+++ b/extensions/openpower-pels/registry/schema/schema.json
@@ -534,18 +534,8 @@
         },
 
         "procedure": {
-            "description": "The maintenance procedure callout.",
-            "type": "string",
-            "enum": [
-                "bmc_code",
-                "next_level_support",
-                "sbe_code",
-                "fsi_path",
-                "power_overcurrent",
-                "find_sue_root_cause",
-                "system_vpd_correction",
-                "detected_issue_need_service"
-            ]
+            "description": "The maintenance procedure callout. List of available procedures is at https://github.com/ibm-openbmc/openpower-pel-parsers/blob/master/modules/calloutparsers/ocallouts/ocallouts.py ",
+            "type": "string"
         },
 
         "useInventoryLocCode": {

--- a/extensions/openpower-pels/src.cpp
+++ b/extensions/openpower-pels/src.cpp
@@ -1036,8 +1036,8 @@ void SRC::addRegistryCallout(
     if (!regCallout.procedure.empty())
     {
         // Procedure callout
-        callout = std::make_unique<src::Callout>(priority,
-                                                 regCallout.procedure);
+        callout = std::make_unique<src::Callout>(priority, regCallout.procedure,
+                                                 src::CalloutValueType::raw);
     }
     else if (!regCallout.symbolicFRU.empty())
     {

--- a/test/openpower-pels/pel_manager_test.cpp
+++ b/test/openpower-pels/pel_manager_test.cpp
@@ -243,7 +243,7 @@ TEST_F(ManagerTest, TestCreateWithMessageRegistry)
             "Callouts": [
                 {
                     "CalloutList": [
-                        {"Priority": "high", "Procedure": "bmc_code"},
+                        {"Priority": "high", "Procedure": "BMC0001"},
                         {"Priority": "medium", "SymbolicFRU": "service_docs"}
                     ]
                 }

--- a/test/openpower-pels/registry_test.cpp
+++ b/test/openpower-pels/registry_test.cpp
@@ -458,7 +458,7 @@ TEST_F(RegistryTest, TestGetCallouts)
             [
                 {
                     "Priority": "medium",
-                    "Procedure": "bmc_code"
+                    "Procedure": "BMC0001"
                 },
                 {
                     "Priority": "low",
@@ -503,7 +503,7 @@ TEST_F(RegistryTest, TestGetCallouts)
         EXPECT_EQ(callouts.size(), 2);
         EXPECT_EQ(callouts[0].priority, "medium");
         EXPECT_EQ(callouts[0].locCode, "");
-        EXPECT_EQ(callouts[0].procedure, "bmc_code");
+        EXPECT_EQ(callouts[0].procedure, "BMC0001");
         EXPECT_EQ(callouts[0].symbolicFRU, "");
         EXPECT_EQ(callouts[1].priority, "low");
         EXPECT_EQ(callouts[1].locCode, "P3-C8");
@@ -616,7 +616,7 @@ TEST_F(RegistryTest, TestGetCallouts)
                                 },
                                 {
                                     "Priority": "low",
-                                    "Procedure": "bmc_code",
+                                    "Procedure": "BMC0001",
                                     "CalloutType": "config_procedure"
                                 }
                             ]
@@ -671,7 +671,7 @@ TEST_F(RegistryTest, TestGetCallouts)
             EXPECT_EQ(callouts[1].symbolicFRUTrusted, "");
             EXPECT_EQ(callouts[2].priority, "low");
             EXPECT_EQ(callouts[2].locCode, "");
-            EXPECT_EQ(callouts[2].procedure, "bmc_code");
+            EXPECT_EQ(callouts[2].procedure, "BMC0001");
             EXPECT_EQ(callouts[2].symbolicFRU, "");
             EXPECT_EQ(callouts[2].symbolicFRUTrusted, "");
 

--- a/test/openpower-pels/src_test.cpp
+++ b/test/openpower-pels/src_test.cpp
@@ -478,7 +478,7 @@ TEST_F(SRCTest, RegistryCalloutTest)
                 },
                 {
                     "Priority": "medium",
-                    "Procedure": "bmc_code"
+                    "Procedure": "BMC0001"
                 }
             ]
         },


### PR DESCRIPTION
Use the actual names so that the script that creates IBM's documentation (RCDL files) can pull them in, so that they will show up with the SRCs on IBM's web site.

The other commit is to add some missing SRCs.
