### PR TITLE
PEL: Update sev of critical threshold errors

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -5042,7 +5042,7 @@
             "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureCriticalHigh",
             "Subsystem": "power",
             "ComponentID": "0x2800",
-            "Severity": "predictive",
+            "Severity": "unrecoverable",
             "ActionFlags": ["service_action", "report"],
 
             "SRC": {
@@ -5296,7 +5296,7 @@
             "Name": "xyz.openbmc_project.Sensor.Threshold.Error.VoltageCriticalLow",
             "Subsystem": "cec_tod",
             "ComponentID": "0x2800",
-            "Severity": "predictive",
+            "Severity": "unrecoverable",
             "ActionFlags": ["service_action", "report"],
 
             "SRC": {
@@ -5376,7 +5376,7 @@
             "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperatureCriticalLow",
             "Subsystem": "power",
             "ComponentID": "0x2800",
-            "Severity": "predictive",
+            "Severity": "unrecoverable",
             "ActionFlags": ["service_action", "report"],
 
             "SRC": {


### PR DESCRIPTION
The Temperature/Voltage CriticalHigh/Low PELs previously had a PEL severity of 'predictive', and this commit changes them to 'unrecoverable' so that it matches the D-Bus severity value it's being created with.

Note: The D-Bus severity value is 'critical'.  While there is a PEL severity value of 'critical', both 'unrecoverable' and 'critical' get mapped to the Redfish field value of 'Critical' anyway, and the PEL 'critical' field seems to be just used for system crashes and the like.


Change-Id: I174c48180abe9ddca09d0e020e6d16f81311bb61