### PR TITLE
Audit Log: Return only AUDIT_USYS_CONFIG  records for getLatestEntries

### DIFF
--- a/phosphor-auditlog/alog_parser.cpp
+++ b/phosphor-auditlog/alog_parser.cpp
@@ -227,7 +227,8 @@ bool ALParser::formatMsgReg(nlohmann::json& parsedEntry)
             break;
 
         default:
-            fillAuditEntry(parsedEntry);
+            /* Skip these entries */
+            return false;
             break;
     }
 


### PR DESCRIPTION
Include only the AUDIT_USYS_CONFIG audit records for getLatestEntries. This method provides support for the GUI to display audit records. The GUI display is limited to audit records with known fields provided by the AUDIT_USYS_CONFIG records.