### PR TITLE
Don't allow duplicate PEL callouts

### DIFF
--- a/docs/structured-logging.md
+++ b/docs/structured-logging.md
@@ -109,8 +109,10 @@ Format flags can be OR'd together as necessary: `hex | field32`.
 
 The APIs can handle (and format appropriately) any data of the following types:
 signed or unsigned integers, floating point numbers, booleans, strings
-(C-strings, std::strings, or std::string_views), sdbusplus enums, exceptions,
-and pointers.
+(C-strings, std::strings, or `std::string_views`), sdbusplus enums and
+`object_paths`, generic enumerations (as numbers), exceptions, and pointers. The
+APIs will also allow arbitrary type formatting for any type which has a
+`to_string` function defined.
 
 The APIs also perform compile-time analysis of the arguments to give descriptive
 error messages for incorrect parameters or format flags. Some examples are:

--- a/extensions/openpower-pels/callout.cpp
+++ b/extensions/openpower-pels/callout.cpp
@@ -205,6 +205,54 @@ void Callout::flatten(Stream& pel) const
     }
 }
 
+bool Callout::operator==(const Callout& right) const
+{
+    if ((_locationCodeSize != 0) || (right.locationCodeSize() != 0))
+    {
+        return locationCode() == right.locationCode();
+    }
+
+    if (!_fruIdentity || !right.fruIdentity())
+    {
+        return false;
+    }
+
+    auto myProc = _fruIdentity->getMaintProc();
+    auto otherProc = right.fruIdentity()->getMaintProc();
+    if (myProc)
+    {
+        if (otherProc)
+        {
+            return *myProc == *otherProc;
+        }
+        return false;
+    }
+
+    auto myPN = _fruIdentity->getPN();
+    auto otherPN = right.fruIdentity()->getPN();
+    if (myPN && otherPN)
+    {
+        return *myPN == *otherPN;
+    }
+
+    return false;
+}
+
+bool Callout::operator>(const Callout& right) const
+{
+    // Treat all of the mediums the same
+    const std::map<std::uint8_t, int> priorities = {
+        {'H', 10}, {'M', 9}, {'A', 9}, {'B', 9}, {'C', 9}, {'L', 8}};
+
+    if (!priorities.contains(priority()) ||
+        !priorities.contains(right.priority()))
+    {
+        return false;
+    }
+
+    return priorities.at(priority()) > priorities.at(right.priority());
+}
+
 } // namespace src
 } // namespace pels
 } // namespace openpower

--- a/extensions/openpower-pels/callout.hpp
+++ b/extensions/openpower-pels/callout.hpp
@@ -198,6 +198,16 @@ class Callout
     }
 
     /**
+     * @brief Set the priority of the callout
+     *
+     * @param[in] priority - The priority value
+     */
+    void setPriority(uint8_t priority)
+    {
+        _priority = priority;
+    }
+
+    /**
      * @brief Returns the location code of the callout
      *
      * @return std::string - The location code
@@ -252,6 +262,25 @@ class Callout
     {
         return _mru;
     }
+
+    /**
+     * @brief Operator == used for finding duplicate callouts
+     *
+     * Checks if the location codes then maintenance procedure
+     * value, then symbolic FRU value match.
+     *
+     * @param[in] right - The callout to compare to
+     * @return bool - true if they are the same
+     */
+    bool operator==(const Callout& right) const;
+
+    /**
+     * @brief Operator > used for sorting callouts by priority
+     *
+     * @param[in] right - The callout to compare to
+     * @return bool - true if callout has higher priority than other
+     */
+    bool operator>(const Callout& right) const;
 
   private:
     /**

--- a/extensions/openpower-pels/callouts.cpp
+++ b/extensions/openpower-pels/callouts.cpp
@@ -15,7 +15,7 @@
  */
 #include "callouts.hpp"
 
-#include <phosphor-logging/log.hpp>
+#include <phosphor-logging/lg2.hpp>
 
 #include <algorithm>
 
@@ -80,8 +80,7 @@ void Callouts::addCallout(std::unique_ptr<Callout> callout)
         }
         else
         {
-            using namespace phosphor::logging;
-            log<level::INFO>("Dropping PEL callout because at max");
+            lg2::info("Dropping PEL callout because at max");
         }
     }
 

--- a/test/openpower-pels/pel_test.cpp
+++ b/test/openpower-pels/pel_test.cpp
@@ -958,7 +958,8 @@ TEST_F(PELTest, CreateWithJSONCalloutsTest)
     ffdcFile.version = 1;
 
     // Write these callouts to a JSON file and pass it into
-    // the PEL as an FFDC file.
+    // the PEL as an FFDC file. Also has a duplicate that
+    // will be removed.
     auto inputJSON = R"([
         {
             "Priority": "H",
@@ -966,6 +967,10 @@ TEST_F(PELTest, CreateWithJSONCalloutsTest)
         },
         {
             "Priority": "M",
+            "Procedure": "PROCEDURE"
+        },
+        {
+            "Priority": "L",
             "Procedure": "PROCEDURE"
         }
     ])"_json;

--- a/test/openpower-pels/src_callout_test.cpp
+++ b/test/openpower-pels/src_callout_test.cpp
@@ -432,3 +432,128 @@ TEST(CalloutTest, TestSymbolicFRUCallout)
         }
     }
 }
+
+TEST(CalloutTest, OperatorEqualTest)
+{
+    {
+        Callout c1{CalloutPriority::high, "A1", "1234567", "ABCD",
+                   "123456789ABC"};
+        Callout c2{CalloutPriority::high, "A1", "1234567", "ABCD",
+                   "123456789ABC"};
+        EXPECT_EQ(c1, c2);
+    }
+
+    {
+        // Different location code
+        Callout c1{CalloutPriority::high, "A1", "1234567", "ABCD",
+                   "123456789ABC"};
+        Callout c2{CalloutPriority::high, "A2", "1234567", "ABCD",
+                   "123456789ABC"};
+        EXPECT_NE(c1, c2);
+    }
+
+    {
+        // maintenance procedure
+        Callout c1{CalloutPriority::medium, "bmc_code"};
+        Callout c2{CalloutPriority::medium, "bmc_code"};
+        EXPECT_EQ(c1, c2);
+    }
+
+    {
+        // different maintenance procedures
+        Callout c1{CalloutPriority::medium, "bmc_code"};
+        Callout c2{CalloutPriority::medium, "sbe_code"};
+        EXPECT_NE(c1, c2);
+    }
+
+    {
+        // symbolic FRU
+        Callout c1{CalloutPriority::high, "service_docs", "", false};
+        Callout c2{CalloutPriority::high, "service_docs", "", false};
+        EXPECT_EQ(c1, c2);
+    }
+
+    {
+        // different symbolic FRUs
+        Callout c1{CalloutPriority::high, "service_docs", "", false};
+        Callout c2{CalloutPriority::high, "air_mover", "", false};
+        EXPECT_NE(c1, c2);
+    }
+
+    {
+        // HW callout vs symbolic FRU
+        Callout c1{CalloutPriority::high, "A1", "1234567", "ABCD",
+                   "123456789ABC"};
+        Callout c2{CalloutPriority::high, "service_docs", "", false};
+        EXPECT_NE(c1, c2);
+    }
+
+    {
+        // HW callout vs maintenance procedure
+        Callout c1{CalloutPriority::high, "A1", "1234567", "ABCD",
+                   "123456789ABC"};
+        Callout c2{CalloutPriority::medium, "bmc_code"};
+        EXPECT_NE(c1, c2);
+    }
+
+    {
+        // symbolic FRU vs maintenance procedure
+        Callout c1{CalloutPriority::high, "service_docs", "", false};
+        Callout c2{CalloutPriority::medium, "bmc_code"};
+        EXPECT_NE(c1, c2);
+    }
+
+    {
+        // HW callout vs symbolic FRU is still considered equal if
+        // the location code is the same
+        Callout c1{CalloutPriority::high, "A1", "1234567", "ABCD",
+                   "123456789ABC"};
+        Callout c2{CalloutPriority::high, "service_docs", "A1", true};
+        EXPECT_EQ(c1, c2);
+    }
+}
+
+TEST(CalloutTest, OperatorGreaterThanTest)
+{
+    {
+        Callout c1{CalloutPriority::high, "bmc_code"};
+        Callout c2{CalloutPriority::medium, "bmc_code"};
+        EXPECT_TRUE(c1 > c2);
+    }
+    {
+        Callout c1{CalloutPriority::high, "bmc_code"};
+        Callout c2{CalloutPriority::low, "bmc_code"};
+        EXPECT_TRUE(c1 > c2);
+    }
+    {
+        Callout c1{CalloutPriority::medium, "bmc_code"};
+        Callout c2{CalloutPriority::low, "bmc_code"};
+        EXPECT_TRUE(c1 > c2);
+    }
+    {
+        Callout c1{CalloutPriority::mediumGroupA, "bmc_code"};
+        Callout c2{CalloutPriority::low, "bmc_code"};
+        EXPECT_TRUE(c1 > c2);
+    }
+    {
+        Callout c1{CalloutPriority::medium, "bmc_code"};
+        Callout c2{CalloutPriority::high, "bmc_code"};
+        EXPECT_FALSE(c1 > c2);
+    }
+    {
+        Callout c1{CalloutPriority::high, "bmc_code"};
+        Callout c2{CalloutPriority::high, "bmc_code"};
+        EXPECT_FALSE(c1 > c2);
+    }
+    {
+        Callout c1{CalloutPriority::low, "bmc_code"};
+        Callout c2{CalloutPriority::high, "bmc_code"};
+        EXPECT_FALSE(c1 > c2);
+    }
+    {
+        // Treat the different mediums the same
+        Callout c1{CalloutPriority::medium, "bmc_code"};
+        Callout c2{CalloutPriority::mediumGroupA, "bmc_code"};
+        EXPECT_FALSE(c1 > c2);
+    }
+}


### PR DESCRIPTION
When adding callouts, check if the callout being added already exists.
If it does, don't add it and rather just update the priority of the
existing one to be the highest of the two.

Callouts are considered to be equal if their location code matches, or
if they have the same maintenance procedure, or if they have the same
symbolic FRU

This also pulls in some upstream changes to allow lg2 handling of printing enums natively.

Everything here is already merged upstream.
https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/69682
