### PR TITLE
Audit Log: RAS: Skip records which duplicate fields

### DIFF
--- a/phosphor-auditlog/alog_parser.hpp
+++ b/phosphor-auditlog/alog_parser.hpp
@@ -123,8 +123,9 @@ class ALParser
     /**
      * @brief Parses AUDIT_USYS_CONFIG audit entry into JSON format
      * @details Expected fields from audit log entry are split into MessageArgs
+     * @return bool True entry was filled in, false otherwise.
      */
-    void fillUsysEntry(nlohmann::json& parsedEntry);
+    bool fillUsysEntry(nlohmann::json& parsedEntry);
 
     /**
      * @brief Opens and truncates specified file


### PR DESCRIPTION
A malformed audit log record being parsed can cause confusion. Don't include these records for the getLatestEntries() method. Add warning message to the journal for any of these records seen to facilitate future debugging.

Fixes: 600216

Tested: Recreated bmcweb core dump. Installed fix and tried again. Confirmed malformed entries are not returned and journal message for debugging is recorded.

Fix for bmcweb also coded: https://github.com/ibm-openbmc/bmcweb/pull/842