### PR TITLE
PEL: Add POZ PEL Parser

### DIFF
--- a/extensions/openpower-pels/registry/O_component_ids.json
+++ b/extensions/openpower-pels/registry/O_component_ids.json
@@ -11,6 +11,7 @@
     "3600": "bmc code management",
     "3700": "bmc debug collector",
     "4000": "bmc vpd",
+    "4500": "bmc POZ PEL parser",
     "5000": "bmc panel",
     "6000": "bmc pldm",
     "C100": "bmc system dump collector",
@@ -18,6 +19,5 @@
     "D100": "bmc hw diags attention handler",
     "E500": "bmc hw diags",
     "F100": "bmc faultlog",
-    "F300": "bmc memory ECC errors",
-    "F400": "bmc ocmb errors"
+    "F300": "bmc memory ECC errors"
 }

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6726,10 +6726,10 @@
         {
             "Name": "org.open_power.OCMB.Error.SbeChipOpFailure",
             "Subsystem": "memory",
-            "ComponentID": "0xF400",
+            "ComponentID": "0x4500",
 
             "SRC": {
-                "ReasonCode": "0xF401",
+                "ReasonCode": "0x4501",
                 "Words6To9": {
                     "6": {
                         "Description": "[0:15] chip position, [16:23] command class, [24:31] command type",
@@ -6757,10 +6757,10 @@
         {
             "Name": "org.open_power.OCMB.Error.SbeChipOpTimeout",
             "Subsystem": "memory",
-            "ComponentID": "0xF400",
+            "ComponentID": "0x4500",
 
             "SRC": {
-                "ReasonCode": "0xF402",
+                "ReasonCode": "0x4502",
                 "Words6To9": {
                     "6": {
                         "Description": "[0:15] chip position, [16:23] command class, [24:31] command type",


### PR DESCRIPTION
Parser to parse the POZ PLAT data in the PEL. Changing the component ID from F400 to 4500 to be used for all the SBE's PEL data parsers. "o3500.py" will handle only P10 processor SBE. "o4500.py" will be for Odyssey and Pfuture chips.

Change-Id: I4be341888b6ea7a0b999b3e4555604b4d39ea4ce