### PR TITLE
1060: PEL: Fix PEL to callout PGDPART symbolic FRU

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -2513,7 +2513,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "LocCode": "P0"
+                            "SymbolicFRU": "pgood_part"
                         }
                     ]
                 }


### PR DESCRIPTION
#### PEL: Fix PEL to callout PGDPART symbolic FRU
```
Tested:
  Injected a error and verified the output
  busctl call xyz.openbmc_project.Logging /xyz/openbmc_project/logging \
  xyz.openbmc_project.Logging.Create Create ssa{ss} \
  xyz.openbmc_project.State.Shutdown.Power.Error.Regulator \
  xyz.openbmc_project.Logging.Entry.Level.Critical 0

'''
  peltool -l
{
    "0x5000012C": {
        "SRC":                  "11002602",
        "Message":              "A power off was issued because a regulator for standby power faulted",
        "PLID":                 "0x5000012C",
        "CreatorID":            "BMC",
        "Subsystem":            "Power Control Hardware",
        "Commit Time":          "03/28/2024 02:49:10",
        "Sev":                  "Critical Error, System Termination",
        "CompID":               "bmc power and thermal"
    }
}
'''

peltool -i 0x5000012C
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc power and thermal",
    "Created at":               "03/28/2024 02:49:10",
    "Committed at":             "03/28/2024 02:49:10",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x5000012C",
    "Entry Id":                 "0x5000012C",
    "BMC Event Log Id":         "32"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "Power Control Hardware",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Critical Error, System Termination",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",
    "HMC Transmission":         "Acked"
},
'''
"Primary SRC": {
    "Section Version":          "1",
    "Sub-section type":         "1",
    "Created by":               "bmc power and thermal",
    "SRC Version":              "0x02",
    "SRC Format":               "0x55",
    "Virtual Progress SRC":     "False",
    "I5/OS Service Event Bit":  "False",
    "Hypervisor Dump Initiated":"False",
    "Backplane CCIN":           "2E44",
    "Terminate FW Error":       "True",
    "Deconfigured":             "False",
    "Guarded":                  "False",
    "Error Details": {
        "Message":              "A power off was issued because a regulator for standby power faulted"
    },
    "Valid Word Count":         "0x09",
    "Reference Code":           "11002602",
    "Hex Word 2":               "00000055",
    "Hex Word 3":               "2E440010",
    "Hex Word 4":               "11002602",
    "Hex Word 5":               "20000000",
    "Hex Word 6":               "00000000",
    "Hex Word 7":               "00000000",
    "Hex Word 8":               "00000000",
    "Hex Word 9":               "00000000",
    "Callout Section": {
        "Callout Count":        "1",
        "Callouts": [{
            "FRU Type":         "Symbolic FRU",
            "Priority":         "Mandatory, replace all with this type as a unit",
            "Part Number":      "PGDPART"
        }]
    }
},
'''
"Extended User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc error logging",
    "Reporting Machine Type":   "9028-21B",
    "Reporting Serial Number":  "788C451",
    "FW Released Ver":          "NL1060_034",
    "FW SubSys Version":        "fw1060.00-4.36",
    "Common Ref Time":          "00/00/0000 00:00:00",
    "Symptom Id Len":           "20",
    "Symptom Id":               "11002602_2E440010"
}
'''

Change-Id: I87418ffc51e0a2eb98e795c53c209965b81cfcd9
Signed-off-by: Faisal Awada <faisal@us.ibm.com>
```