### PR TITLE
PEL: Message_registry: Add File Recovery PEL

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -352,6 +352,34 @@
         },
 
         {
+            "Name": "xyz.openbmc_project.Common.File.Error.FileRecoveredOnBmcReboot",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x1000",
+            "SRC": {
+                "ReasonCode": "0x1010",
+                "Words6To9": {
+                    "6": {
+                        "Description": "Size of the File in running partition",
+                        "AdditionalDataPropSource": "CURRENT_FILE_SIZE"
+                    },
+                    "7": {
+                        "Description": "Size of the File in read only partition",
+                        "AdditionalDataPropSource": "EXPECTED_FILE_SIZE"
+                    }
+                }
+            },
+            "Documentation": {
+                "Description": "Recovered the corrupted or empty lid file",
+                "Message": "The lid file is restored from the older copy",
+                "Notes": [
+                    "This error may occur if one of the file marked ",
+                    "PRESERVED or DEVTREE is corrupted and the file ",
+                    "is restored from the readonly version. We may have lost data."
+                ]
+            }
+        },
+
+        {
             "Name": "org.open_power.Logging.Error.SentBadPELToHost",
             "Subsystem": "bmc_firmware",
             "Severity": "non_error",


### PR DESCRIPTION
This commit addresses the issue where device tree file corruption could lead to the failure of the BMC to boot up. Corruption of the file may occur during a kernel panic. In such instances, recovery of the previous uncorrupted version of the file from the available read-only version is now implemented. The PEL information needed to be logged during this scenario is added as part of this commit.

Test output:
{
"Private Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Created by":               "bmc host processor control",
    "Created at":               "04/01/2024 11:02:22",
    "Committed at":             "04/01/2024 11:02:22",
    "Creator Subsystem":        "BMC",
    "CSSVER":                   "",
    "Platform Log Id":          "0x5000AEE5",
    "Entry Id":                 "0x5000AEE5",
    "BMC Event Log Id":         "1395"
},
"User Header": {
    "Section Version":          "1",
    "Sub-section type":         "0",
    "Log Committed by":         "bmc error logging",
    "Subsystem":                "BMC Firmware",
    "Event Scope":              "Entire Platform",
    "Event Severity":           "Predictive Error",
    "Event Type":               "Not Applicable",
    "Action Flags": [
                                "Service Action Required",
                                "Report Externally",
                                "HMC Call Home"
    ],
    "Host Transmission":        "Not Sent",