### PR TITLE
1060:CI-only: create detect-secrets baseline file

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,152 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-26T19:34:59Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "lib/include/phosphor-logging/lg2/header.hpp": [
+      {
+        "hashed_secret": "b8c53c14e51596aa7981ab63bfaa465abe302a92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/elog_quiesce_test.cpp": [
+      {
+        "hashed_secret": "f149fb62792bdd0313b49a71a962aab588c41205",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 214,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/openpower-pels/extended_user_header_test.cpp": [
+      {
+        "hashed_secret": "dbd5aad61e85697374b49bb453e365024ada70b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/openpower-pels/mtms_test.cpp": [
+      {
+        "hashed_secret": "e5b7c4127aafba67a278e17881ff55132110f7ac",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 48,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/openpower-pels/src_test.cpp": [
+      {
+        "hashed_secret": "c60646de4c4893cf860a12ecb7ba4f5317b1a1d0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 898,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9fd1b80e175b3104ea1da0c4a75292f8e2e8cede",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 907,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bc2a140261b87d91c28d03d5981e18770b55dd67",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1293,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}


### PR DESCRIPTION
This creates a baseline file (and initial responses to any potential secrets found).

After this file is merged, all CI jobs after will run the detect-secrets tool against incoming commits to verify no potential secrets are being shared. If one is found, CI will fail until the .secrets.baseline is updated for the new issue.

See the following for more info:
  https://github.com/IBM/detect-secrets