### PR TITLE
1060: PEL: Fixing procedure name in callout details

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6835,7 +6835,7 @@
                     "CalloutList": [
                         {
                             "Priority": "high",
-                            "Procedure": "next_level_support"
+                            "Procedure": "BMC0002"
                         }
                     ]
                 }


### PR DESCRIPTION
#### PEL: Fixing procedure name in callout details
```
In the newly introduced PEL in the callout details
we had procedure name as "next_level_support" but
recently made a change to expose the procedure
callouts in the RCDL because service said they needed
them. This changes fixes this missing actual procedure
name from next_level_support to BMC0002.

Signed-off-by: Swarnendu Roy Chowdhury <swarnendu.roy.chowdhury@ibm.com>
Change-Id: I7f49ca37cef3c6f49fc08808b68fdd9f72549b25
```