### PR TITLE
PEL: Updating sev for set host effecter failure

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6493,7 +6493,7 @@
             "Name": "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
             "Subsystem": "bmc_firmware",
             "ComponentID": "0x6000",
-            "Severity": "unrecoverable",
+            "Severity": "non_error",
             "SRC": {
                 "ReasonCode": "0x6017",
                 "Words6To9": {}


### PR DESCRIPTION
This commit updates the severity of  PEL
'xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed' from UNRECOVERABLE ERROR to INFORMATIONAL.