### PR TITLE
1030: PEL: Updating sev for set host effecter failure (#60)

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -5453,7 +5453,7 @@
             "Name": "xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed",
             "Subsystem": "bmc_firmware",
             "ComponentID": "0x6000",
-            "Severity": "unrecoverable",
+            "Severity": "non_error",
             "SRC":
             {
                 "ReasonCode": "0x6017",


### PR DESCRIPTION
#### PEL: Updating sev for set host effecter failure (#60)
```
This commit updates the severity of  PEL
'xyz.openbmc_project.PLDM.Error.SetHostEffecterFailed' from
UNRECOVERABLE ERROR to INFORMATIONAL.

Signed-off-by: Riya Dixit <riyadixitagra@gmail.com>
```