### PR TITLE
PEL: Adding BMC PEL for PLDM error

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6692,6 +6692,48 @@
             }
         },
         {
+            "Name": "xyz.openbmc_project.PLDM.Error.ReportResourceDumpFail.NewFileAvailableRequest",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x6000",
+            "Severity": "predictive",
+            "SRC": {
+                "ReasonCode": "0x6027",
+                "Words6To9": {}
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "BMC0001" }
+                    ]
+                }
+            ],
+            "Documentation": {
+                "Description": "Failed to send NewFileAvailable request to remote terminus.",
+                "Message": "Failed to send NewFileAvailable request to remote terminus."
+            }
+        },
+        {
+            "Name": "xyz.openbmc_project.PLDM.Error.ReportResourceDumpFail.DecodeNewFileResp",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x6000",
+            "Severity": "predictive",
+            "SRC": {
+                "ReasonCode": "0x6028",
+                "Words6To9": {}
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "BMC0001" }
+                    ]
+                }
+            ],
+            "Documentation": {
+                "Description": "Failed to decode NewFileAvailable response",
+                "Message": "Failed to decode NewFileAvailable response"
+            }
+        },
+        {
             "Name": "xyz.openbmc_project.Memory.MemoryECC.Error.CEThresholdReached",
             "Subsystem": "cec_hardware",
             "ComponentID": "0xF300",


### PR DESCRIPTION
This commit adds BMC pels for PLDM error so as to report resource dump failure.