### PR TITLE
build: upgrade to C++23

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,8 @@
 project('phosphor-logging', 'cpp',
-    meson_version: '>= 0.58.0',
+    meson_version: '>=1.1.1',
     default_options: [
       'buildtype=debugoptimized',
-      'cpp_std=c++20',
+      'cpp_std=c++23',
       'warning_level=3',
       'werror=true',
       'libonly=' + (meson.is_subproject() ? 'true' : 'false'),


### PR DESCRIPTION
Meson 1.1.1 and GCC-13 both support C++23 and a sufficient portion of the standard has been implemented.  Upgrade the build to leverage it.

Change-Id: I91d92825b38ece8aaf519f62072ce0f1d5aa6b1c