### PR TITLE
Revert openpower-pels: Move to libpldm pldm_transport APIs

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -87,7 +87,7 @@ IndentWidth:     4
 IndentWrappedFunctionNames: true
 InsertNewlineAtEOF: true
 KeepEmptyLinesAtTheStartOfBlocks: false
-LambdaBodyIndentation: OuterScope
+LambdaBodyIndentation: Signature
 LineEnding: LF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
@@ -98,13 +98,14 @@ ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 25
-PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakBeforeFirstCallParameter: 50
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
-PenaltyIndentedWhitespace: 0
+PenaltyIndentedWhitespace: 1
 PointerAlignment: Left
 QualifierAlignment: Left
 ReferenceAlignment: Left

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,152 @@
+{
+  "exclude": {
+    "files": "^.secrets.baseline$",
+    "lines": null
+  },
+  "generated_at": "2024-04-26T19:34:59Z",
+  "plugins_used": [
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "base64_limit": 4.5,
+      "name": "Base64HighEntropyString"
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "BoxDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "ghe_instance": "github.ibm.com",
+      "name": "GheDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "hex_limit": 3,
+      "name": "HexHighEntropyString"
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "keyword_exclude": null,
+      "name": "KeywordDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "results": {
+    "lib/include/phosphor-logging/lg2/header.hpp": [
+      {
+        "hashed_secret": "b8c53c14e51596aa7981ab63bfaa465abe302a92",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 33,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/elog_quiesce_test.cpp": [
+      {
+        "hashed_secret": "f149fb62792bdd0313b49a71a962aab588c41205",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 214,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/openpower-pels/extended_user_header_test.cpp": [
+      {
+        "hashed_secret": "dbd5aad61e85697374b49bb453e365024ada70b0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 185,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/openpower-pels/mtms_test.cpp": [
+      {
+        "hashed_secret": "e5b7c4127aafba67a278e17881ff55132110f7ac",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 48,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      }
+    ],
+    "test/openpower-pels/src_test.cpp": [
+      {
+        "hashed_secret": "c60646de4c4893cf860a12ecb7ba4f5317b1a1d0",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 898,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "9fd1b80e175b3104ea1da0c4a75292f8e2e8cede",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 907,
+        "type": "Hex High Entropy String",
+        "verified_result": null
+      },
+      {
+        "hashed_secret": "bc2a140261b87d91c28d03d5981e18770b55dd67",
+        "is_secret": false,
+        "is_verified": false,
+        "line_number": 1293,
+        "type": "Base64 High Entropy String",
+        "verified_result": null
+      }
+    ]
+  },
+  "version": "0.13.1+ibm.62.dss",
+  "word_list": {
+    "file": null,
+    "hash": null
+  }
+}

--- a/dist/busconfig/phosphor-auditlog-config.conf
+++ b/dist/busconfig/phosphor-auditlog-config.conf
@@ -1,0 +1,8 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy group="root">
+    <allow own="xyz.openbmc_project.Logging.AuditLog"/>
+    <allow send_destination="xyz.openbmc_project.Logging.AuditLog"/>
+  </policy>
+</busconfig>

--- a/dist/meson.build
+++ b/dist/meson.build
@@ -3,17 +3,26 @@ systemd_system_unit_dir = dependency('systemd').get_variable(
 
 install_data(
     ['xyz.openbmc_project.Logging.service',
-     'xyz.openbmc_project.Syslog.Config.service',
-     'xyz.openbmc_project.Logging.AuditLog.service'],
+     'xyz.openbmc_project.Syslog.Config.service'],
     install_dir: systemd_system_unit_dir,
 )
 
 install_data(
     'busconfig/phosphor-logging.conf',
     'busconfig/phosphor-rsyslog-config.conf',
-    'busconfig/phosphor-auditlog-config.conf',
     install_dir: get_option('datadir') / 'dbus-1' / 'system.d',
 )
+
+if(get_option('auditlog').enabled())
+    install_data(
+        'xyz.openbmc_project.Logging.AuditLog.service',
+        install_dir: systemd_system_unit_dir,
+    )
+    install_data(
+        'busconfig/phosphor-auditlog-config.conf',
+        install_dir: get_option('datadir') / 'dbus-1' / 'system.d',
+    )
+endif
 
 dbus_system_bus_services_dir = dependency('dbus-1').get_variable(
     'system_bus_services_dir',

--- a/dist/meson.build
+++ b/dist/meson.build
@@ -3,13 +3,15 @@ systemd_system_unit_dir = dependency('systemd').get_variable(
 
 install_data(
     ['xyz.openbmc_project.Logging.service',
-     'xyz.openbmc_project.Syslog.Config.service'],
+     'xyz.openbmc_project.Syslog.Config.service',
+     'xyz.openbmc_project.Logging.AuditLog.service'],
     install_dir: systemd_system_unit_dir,
 )
 
 install_data(
     'busconfig/phosphor-logging.conf',
     'busconfig/phosphor-rsyslog-config.conf',
+    'busconfig/phosphor-auditlog-config.conf',
     install_dir: get_option('datadir') / 'dbus-1' / 'system.d',
 )
 

--- a/dist/xyz.openbmc_project.Logging.AuditLog.service
+++ b/dist/xyz.openbmc_project.Logging.AuditLog.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Audit Log Services
+
+[Service]
+ExecStart=/usr/bin/phosphor-auditlog
+Restart=always
+Type=dbus
+BusName=xyz.openbmc_project.Logging.AuditLog
+
+[Install]
+WantedBy=multi-user.target

--- a/elog_block.hpp
+++ b/elog_block.hpp
@@ -43,11 +43,11 @@ class Block : public BlockIface
     Block(sdbusplus::bus_t& bus, const std::string& path, uint32_t entryId) :
         BlockIface(bus, path.c_str()), entryId(entryId)
     {
-        std::string entryPath{std::string(OBJ_ENTRY) + '/' +
-                              std::to_string(entryId)};
-        AssociationList assoc{std::make_tuple(std::string{"blocking_error"},
-                                              std::string{"blocking_obj"},
-                                              entryPath)};
+        std::string entryPath{
+            std::string(OBJ_ENTRY) + '/' + std::to_string(entryId)};
+        AssociationList assoc{
+            std::make_tuple(std::string{"blocking_error"},
+                            std::string{"blocking_obj"}, entryPath)};
         associations(std::move(assoc));
     };
 

--- a/elog_entry.hpp
+++ b/elog_entry.hpp
@@ -79,8 +79,8 @@ class Entry : public EntryIfaces
         associations(std::move(objects), true);
         // Store a copy of associations in case we need to recreate
         assocs = associations();
-        sdbusplus::server::xyz::openbmc_project::logging::Entry::resolved(false,
-                                                                          true);
+        sdbusplus::server::xyz::openbmc_project::logging::Entry::resolved(
+            false, true);
 
         version(fwVersion, true);
         purpose(VersionPurpose::BMC, true);

--- a/elog_meta.cpp
+++ b/elog_meta.cpp
@@ -49,9 +49,9 @@ void build<
     auto iter = metadata.find(match);
     if (metadata.end() != iter)
     {
-        list.emplace_back(std::make_tuple(CALLOUT_FWD_ASSOCIATION,
-                                          CALLOUT_REV_ASSOCIATION,
-                                          std::string(iter->second.c_str())));
+        list.emplace_back(
+            std::make_tuple(CALLOUT_FWD_ASSOCIATION, CALLOUT_REV_ASSOCIATION,
+                            std::string(iter->second.c_str())));
     }
 }
 

--- a/elog_meta.hpp
+++ b/elog_meta.hpp
@@ -81,18 +81,16 @@ void build(const std::string& match, const std::vector<std::string>& data,
 // for this metadata.
 using namespace example::xyz::openbmc_project::example::elog;
 template <>
-inline void
-    build<TestErrorTwo::DEV_ID>(const std::string& /*match*/,
-                                const std::vector<std::string>& /*data*/,
-                                AssociationList& /*list*/)
+inline void build<TestErrorTwo::DEV_ID>(
+    const std::string& /*match*/, const std::vector<std::string>& /*data*/,
+    AssociationList& /*list*/)
 {}
 
 template <>
-inline void
-    build<example::xyz::openbmc_project::example::device::Callout::
-              CALLOUT_DEVICE_PATH_TEST>(const std::string& match,
-                                        const std::vector<std::string>& data,
-                                        AssociationList& list)
+inline void build<example::xyz::openbmc_project::example::device::Callout::
+                      CALLOUT_DEVICE_PATH_TEST>(
+    const std::string& match, const std::vector<std::string>& data,
+    AssociationList& list)
 {
     std::map<std::string, std::string> metadata;
     parse(data, metadata);

--- a/elog_serialize.hpp
+++ b/elog_serialize.hpp
@@ -38,9 +38,8 @@ bool deserialize(const fs::path& path, Entry& e);
  *                   be placed.
  *  @return fs::path - pathname of persisted error file
  */
-fs::path
-    getEntrySerializePath(uint32_t id,
-                          const fs::path& dir = fs::path(ERRLOG_PERSIST_PATH));
+fs::path getEntrySerializePath(
+    uint32_t id, const fs::path& dir = fs::path(ERRLOG_PERSIST_PATH));
 
 } // namespace logging
 } // namespace phosphor

--- a/extensions/openpower-pels/bcd_time.hpp
+++ b/extensions/openpower-pels/bcd_time.hpp
@@ -30,9 +30,8 @@ struct BCDTime
     BCDTime(uint8_t yearMSB, uint8_t yearLSB, uint8_t month, uint8_t day,
             uint8_t hour, uint8_t minutes, uint8_t seconds,
             uint8_t hundredths) :
-        yearMSB(yearMSB),
-        yearLSB(yearLSB), month(month), day(day), hour(hour), minutes(minutes),
-        seconds(seconds), hundredths(hundredths)
+        yearMSB(yearMSB), yearLSB(yearLSB), month(month), day(day), hour(hour),
+        minutes(minutes), seconds(seconds), hundredths(hundredths)
     {}
 
     bool operator==(const BCDTime& right) const;

--- a/extensions/openpower-pels/callout.cpp
+++ b/extensions/openpower-pels/callout.cpp
@@ -96,8 +96,8 @@ Callout::Callout(CalloutPriority priority, const std::string& locationCode,
 
     setLocationCode(locationCode);
 
-    _fruIdentity = std::make_unique<FRUIdentity>(partNumber, ccin,
-                                                 serialNumber);
+    _fruIdentity =
+        std::make_unique<FRUIdentity>(partNumber, ccin, serialNumber);
 
     if (!mrus.empty())
     {
@@ -132,8 +132,8 @@ Callout::Callout(CalloutPriority priority, const std::string& symbolicFRU,
 
     setLocationCode(locationCode);
 
-    _fruIdentity = std::make_unique<FRUIdentity>(symbolicFRU, type,
-                                                 trustedLocationCode);
+    _fruIdentity =
+        std::make_unique<FRUIdentity>(symbolicFRU, type, trustedLocationCode);
 
     _size = flattenedSize();
 }

--- a/extensions/openpower-pels/callouts.cpp
+++ b/extensions/openpower-pels/callouts.cpp
@@ -55,8 +55,9 @@ void Callouts::addCallout(std::unique_ptr<Callout> callout)
     bool shouldAdd = true;
 
     // Check if there is already a callout for this FRU
-    auto it = std::ranges::find_if(
-        _callouts, [&callout](const auto& c) { return *callout == *c; });
+    auto it = std::ranges::find_if(_callouts, [&callout](const auto& c) {
+        return *callout == *c;
+    });
 
     // If the callout already exists, but the new one has a higher
     // priority, change the existing callout's priority to this

--- a/extensions/openpower-pels/data_interface.cpp
+++ b/extensions/openpower-pels/data_interface.cpp
@@ -133,96 +133,96 @@ DataInterface::DataInterface(sdbusplus::bus_t& bus) : _bus(bus)
     _properties.emplace_back(std::make_unique<PropertyWatcher<DataInterface>>(
         bus, object_path::hostState, interface::bootProgress, "BootProgress",
         *this, [this](const auto& value) {
-        this->_bootState = std::get<std::string>(value);
-        auto status = Progress::convertProgressStagesFromString(
-            std::get<std::string>(value));
+            this->_bootState = std::get<std::string>(value);
+            auto status = Progress::convertProgressStagesFromString(
+                std::get<std::string>(value));
 
-        if ((status == Progress::ProgressStages::SystemInitComplete) ||
-            (status == Progress::ProgressStages::OSRunning))
-        {
-            setHostUp(true);
-        }
-        else
-        {
-            setHostUp(false);
-        }
-    }));
+            if ((status == Progress::ProgressStages::SystemInitComplete) ||
+                (status == Progress::ProgressStages::OSRunning))
+            {
+                setHostUp(true);
+            }
+            else
+            {
+                setHostUp(false);
+            }
+        }));
 
     // Watch the host PEL enable property
     _properties.emplace_back(std::make_unique<PropertyWatcher<DataInterface>>(
         bus, object_path::enableHostPELs, interface::enable, "Enabled", *this,
         [this](const auto& value) {
-        if (std::get<bool>(value) != this->_sendPELsToHost)
-        {
-            lg2::info("The send PELs to host setting changed to {VAL}", "VAL",
-                      std::get<bool>(value));
-        }
-        this->_sendPELsToHost = std::get<bool>(value);
-    }));
+            if (std::get<bool>(value) != this->_sendPELsToHost)
+            {
+                lg2::info("The send PELs to host setting changed to {VAL}",
+                          "VAL", std::get<bool>(value));
+            }
+            this->_sendPELsToHost = std::get<bool>(value);
+        }));
 
     // Watch the BMCState property
     _properties.emplace_back(std::make_unique<PropertyWatcher<DataInterface>>(
         bus, object_path::bmcState, interface::bmcState, "CurrentBMCState",
         *this, [this](const auto& value) {
-        const auto& state = std::get<std::string>(value);
-        this->_bmcState = state;
+            const auto& state = std::get<std::string>(value);
+            this->_bmcState = state;
 
-        // Wait for BMC ready to start watching for
-        // plugs so things calm down first.
-        if (BMC::convertBMCStateFromString(state) == BMC::BMCState::Ready)
-        {
-            startFruPlugWatch();
-        }
-    }));
+            // Wait for BMC ready to start watching for
+            // plugs so things calm down first.
+            if (BMC::convertBMCStateFromString(state) == BMC::BMCState::Ready)
+            {
+                startFruPlugWatch();
+            }
+        }));
 
     // Watch the chassis current and requested power state properties
     _properties.emplace_back(std::make_unique<InterfaceWatcher<DataInterface>>(
         bus, object_path::chassisState, interface::chassisState, *this,
         [this](const auto& properties) {
-        auto state = properties.find("CurrentPowerState");
-        if (state != properties.end())
-        {
-            this->_chassisState = std::get<std::string>(state->second);
-        }
+            auto state = properties.find("CurrentPowerState");
+            if (state != properties.end())
+            {
+                this->_chassisState = std::get<std::string>(state->second);
+            }
 
-        auto trans = properties.find("RequestedPowerTransition");
-        if (trans != properties.end())
-        {
-            this->_chassisTransition = std::get<std::string>(trans->second);
-        }
-    }));
+            auto trans = properties.find("RequestedPowerTransition");
+            if (trans != properties.end())
+            {
+                this->_chassisTransition = std::get<std::string>(trans->second);
+            }
+        }));
 
     // Watch the CurrentHostState property
     _properties.emplace_back(std::make_unique<PropertyWatcher<DataInterface>>(
         bus, object_path::hostState, interface::hostState, "CurrentHostState",
         *this, [this](const auto& value) {
-        this->_hostState = std::get<std::string>(value);
-    }));
+            this->_hostState = std::get<std::string>(value);
+        }));
 
     // Watch the BaseBIOSTable property for the hmc managed attribute
     _properties.emplace_back(std::make_unique<PropertyWatcher<DataInterface>>(
         bus, object_path::biosConfigMgr, interface::biosConfigMgr,
         "BaseBIOSTable", service_name::biosConfigMgr, *this,
         [this](const auto& value) {
-        const auto& attributes = std::get<BiosAttributes>(value);
+            const auto& attributes = std::get<BiosAttributes>(value);
 
-        auto it = attributes.find("pvm_hmc_managed");
-        if (it != attributes.end())
-        {
-            const auto& currentValVariant = std::get<5>(it->second);
-            auto currentVal = std::get_if<std::string>(&currentValVariant);
-            if (currentVal)
+            auto it = attributes.find("pvm_hmc_managed");
+            if (it != attributes.end())
             {
-                this->_hmcManaged = (*currentVal == "Enabled") ? true : false;
+                const auto& currentValVariant = std::get<5>(it->second);
+                auto currentVal = std::get_if<std::string>(&currentValVariant);
+                if (currentVal)
+                {
+                    this->_hmcManaged =
+                        (*currentVal == "Enabled") ? true : false;
+                }
             }
-        }
-    }));
+        }));
 }
 
-DBusPropertyMap
-    DataInterface::getAllProperties(const std::string& service,
-                                    const std::string& objectPath,
-                                    const std::string& interface) const
+DBusPropertyMap DataInterface::getAllProperties(
+    const std::string& service, const std::string& objectPath,
+    const std::string& interface) const
 {
     DBusPropertyMap properties;
 
@@ -236,11 +236,10 @@ DBusPropertyMap
     return properties;
 }
 
-void DataInterface::getProperty(const std::string& service,
-                                const std::string& objectPath,
-                                const std::string& interface,
-                                const std::string& property,
-                                DBusValue& value) const
+void DataInterface::getProperty(
+    const std::string& service, const std::string& objectPath,
+    const std::string& interface, const std::string& property,
+    DBusValue& value) const
 {
     auto method = _bus.new_method_call(service.c_str(), objectPath.c_str(),
                                        interface::dbusProperty, "Get");
@@ -367,8 +366,8 @@ std::string DataInterface::getMotherboardCCIN() const
 
     try
     {
-        auto service = getService(object_path::motherBoardInv,
-                                  interface::viniRecordVPD);
+        auto service =
+            getService(object_path::motherBoardInv, interface::viniRecordVPD);
         if (!service.empty())
         {
             DBusValue value;
@@ -395,8 +394,8 @@ std::vector<uint8_t> DataInterface::getSystemIMKeyword() const
 
     try
     {
-        auto service = getService(object_path::motherBoardInv,
-                                  interface::vsbpRecordVPD);
+        auto service =
+            getService(object_path::motherBoardInv, interface::vsbpRecordVPD);
         if (!service.empty())
         {
             DBusValue value;
@@ -416,10 +415,9 @@ std::vector<uint8_t> DataInterface::getSystemIMKeyword() const
     return systemIM;
 }
 
-void DataInterface::getHWCalloutFields(const std::string& inventoryPath,
-                                       std::string& fruPartNumber,
-                                       std::string& ccin,
-                                       std::string& serialNumber) const
+void DataInterface::getHWCalloutFields(
+    const std::string& inventoryPath, std::string& fruPartNumber,
+    std::string& ccin, std::string& serialNumber) const
 {
     // For now, attempt to get all of the properties directly on the path
     // passed in.  In the future, may need to make use of an algorithm
@@ -430,8 +428,8 @@ void DataInterface::getHWCalloutFields(const std::string& inventoryPath,
 
     auto service = getService(inventoryPath, interface::viniRecordVPD);
 
-    auto properties = getAllProperties(service, inventoryPath,
-                                       interface::viniRecordVPD);
+    auto properties =
+        getAllProperties(service, inventoryPath, interface::viniRecordVPD);
 
     auto value = std::get<std::vector<uint8_t>>(properties["FN"]);
     fruPartNumber = std::string{value.begin(), value.end()};
@@ -498,9 +496,8 @@ std::string DataInterface::expandLocationCode(const std::string& locationCode,
     return expandedLocationCode;
 }
 
-std::vector<std::string>
-    DataInterface::getInventoryFromLocCode(const std::string& locationCode,
-                                           uint16_t node, bool expanded) const
+std::vector<std::string> DataInterface::getInventoryFromLocCode(
+    const std::string& locationCode, uint16_t node, bool expanded) const
 {
     std::string methodName = expanded ? "GetFRUsByExpandedLocationCode"
                                       : "GetFRUsByUnexpandedLocationCode";
@@ -542,9 +539,9 @@ void DataInterface::assertLEDGroup(const std::string& ledGroup,
                                    bool value) const
 {
     DBusValue variant = value;
-    auto method = _bus.new_method_call(service_name::ledGroupManager,
-                                       ledGroup.c_str(),
-                                       interface::dbusProperty, "Set");
+    auto method =
+        _bus.new_method_call(service_name::ledGroupManager, ledGroup.c_str(),
+                             interface::dbusProperty, "Set");
     method.append(interface::ledGroup, "Asserted", variant);
     _bus.call(method, dbusTimeout);
 }
@@ -644,8 +641,8 @@ bool DataInterface::getQuiesceOnError() const
 
     try
     {
-        auto service = getService(object_path::logSetting,
-                                  interface::logSetting);
+        auto service =
+            getService(object_path::logSetting, interface::logSetting);
         if (!service.empty())
         {
             DBusValue value;
@@ -813,8 +810,8 @@ std::vector<uint32_t> DataInterface::getLogIDWithHwIsolation() const
                 // If the entry isn't resolved
                 if (!status)
                 {
-                    auto assocService = getService(path,
-                                                   interface::association);
+                    auto assocService =
+                        getService(path, interface::association);
                     if (!assocService.empty())
                     {
                         DBusValue endpoints;
@@ -931,9 +928,11 @@ void DataInterface::inventoryIfaceAdded(sdbusplus::message_t& msg)
     // Check if any of the new interfaces are for hot pluggable FRUs.
     if (std::find_if(interfaces.begin(), interfaces.end(),
                      [](const auto& interfacePair) {
-        return std::find(hotplugInterfaces.begin(), hotplugInterfaces.end(),
-                         interfacePair.first) != hotplugInterfaces.end();
-    }) == interfaces.end())
+                         return std::find(hotplugInterfaces.begin(),
+                                          hotplugInterfaces.end(),
+                                          interfacePair.first) !=
+                                hotplugInterfaces.end();
+                     }) == interfaces.end())
     {
         return;
     }

--- a/extensions/openpower-pels/data_interface.hpp
+++ b/extensions/openpower-pels/data_interface.hpp
@@ -201,11 +201,11 @@ class DataInterfaceBase
         time_t t(seconds);
         tm* p = gmtime(&t);
 
-        std::string uptime = std::to_string(p->tm_year - 70) + "y " +
-                             std::to_string(p->tm_yday) + "d " +
-                             std::to_string(p->tm_hour) + "h " +
-                             std::to_string(p->tm_min) + "m " +
-                             std::to_string(p->tm_sec) + "s";
+        std::string uptime =
+            std::to_string(p->tm_year - 70) + "y " +
+            std::to_string(p->tm_yday) + "d " + std::to_string(p->tm_hour) +
+            "h " + std::to_string(p->tm_min) + "m " +
+            std::to_string(p->tm_sec) + "s";
 
         return uptime;
     }
@@ -332,10 +332,9 @@ class DataInterfaceBase
      * @param[out] ccin - Filled in with the VINI/CC keyword
      * @param[out] serialNumber - Filled in with the VINI/SN keyword
      */
-    virtual void getHWCalloutFields(const std::string& inventoryPath,
-                                    std::string& fruPartNumber,
-                                    std::string& ccin,
-                                    std::string& serialNumber) const = 0;
+    virtual void getHWCalloutFields(
+        const std::string& inventoryPath, std::string& fruPartNumber,
+        std::string& ccin, std::string& serialNumber) const = 0;
 
     /**
      * @brief Get the location code for an inventory item.

--- a/extensions/openpower-pels/dbus_watcher.hpp
+++ b/extensions/openpower-pels/dbus_watcher.hpp
@@ -100,8 +100,7 @@ class PropertyWatcher : public DBusWatcher
                     const std::string& interface,
                     const std::string& propertyName, const std::string& service,
                     const DataIface& dataIface, PropertySetFunc func) :
-        DBusWatcher(path, interface),
-        _name(propertyName), _setFunc(func)
+        DBusWatcher(path, interface), _name(propertyName), _setFunc(func)
     {
         _matches.emplace_back(
             bus, match_rules::propertiesChanged(_path, _interface),
@@ -279,8 +278,7 @@ class InterfaceWatcher : public DBusWatcher
     InterfaceWatcher(sdbusplus::bus_t& bus, const std::string& path,
                      const std::string& interface, const DataIface& dataIface,
                      InterfaceSetFunc func) :
-        DBusWatcher(path, interface),
-        _setFunc(func)
+        DBusWatcher(path, interface), _setFunc(func)
     {
         _matches.emplace_back(
             bus, match_rules::propertiesChanged(_path, _interface),
@@ -314,8 +312,8 @@ class InterfaceWatcher : public DBusWatcher
         auto service = dataIface.getService(_path, _interface);
         if (!service.empty())
         {
-            auto properties = dataIface.getAllProperties(service, _path,
-                                                         _interface);
+            auto properties =
+                dataIface.getAllProperties(service, _path, _interface);
 
             _setFunc(properties);
         }

--- a/extensions/openpower-pels/device_callouts.cpp
+++ b/extensions/openpower-pels/device_callouts.cpp
@@ -273,9 +273,8 @@ std::vector<Callout> extractCallouts(const nlohmann::json& calloutJSON,
  *
  * @return std::vector<Callout> - The callouts
  */
-std::vector<device_callouts::Callout>
-    calloutI2C(size_t i2cBus, uint8_t i2cAddress,
-               const nlohmann::json& calloutJSON)
+std::vector<device_callouts::Callout> calloutI2C(
+    size_t i2cBus, uint8_t i2cAddress, const nlohmann::json& calloutJSON)
 {
     auto busString = std::to_string(i2cBus);
     auto addrString = std::to_string(i2cAddress);
@@ -312,9 +311,8 @@ std::vector<device_callouts::Callout>
  *
  * @return std::vector<Callout> - The callouts
  */
-std::vector<device_callouts::Callout>
-    calloutI2CUsingPath(const std::string& devPath,
-                        const nlohmann::json& calloutJSON)
+std::vector<device_callouts::Callout> calloutI2CUsingPath(
+    const std::string& devPath, const nlohmann::json& calloutJSON)
 {
     auto [bus, address] = getI2CSearchKeys(devPath);
 
@@ -447,8 +445,8 @@ std::vector<device_callouts::Callout>
  *
  * @return std::vector<Callout> - The list of callouts
  */
-std::vector<device_callouts::Callout> findCallouts(const std::string& devPath,
-                                                   const nlohmann::json& json)
+std::vector<device_callouts::Callout>
+    findCallouts(const std::string& devPath, const nlohmann::json& json)
 {
     std::vector<Callout> callouts;
     fs::path path;
@@ -479,8 +477,8 @@ std::vector<device_callouts::Callout> findCallouts(const std::string& devPath,
             callouts = calloutFSISPI(path, json);
             break;
         default:
-            std::string msg = "Could not get callout type from device path: " +
-                              path.string();
+            std::string msg =
+                "Could not get callout type from device path: " + path.string();
             throw std::invalid_argument{msg.c_str()};
             break;
     }

--- a/extensions/openpower-pels/device_callouts.hpp
+++ b/extensions/openpower-pels/device_callouts.hpp
@@ -99,9 +99,8 @@ struct Callout
  *                             system.
  * @return std::vector<Callout> - The list of callouts
  */
-std::vector<Callout>
-    getCallouts(const std::string& devPath,
-                const std::vector<std::string>& compatibleList);
+std::vector<Callout> getCallouts(
+    const std::string& devPath, const std::vector<std::string>& compatibleList);
 
 /**
  * @brief Looks up the callouts to add to a PEL for when the path
@@ -153,9 +152,8 @@ std::filesystem::path
  *
  * @return std::vector<Callout> - The callouts
  */
-std::vector<device_callouts::Callout>
-    calloutI2C(size_t i2CBus, uint8_t i2cAddress,
-               const nlohmann::json& calloutJSON);
+std::vector<device_callouts::Callout> calloutI2C(
+    size_t i2CBus, uint8_t i2cAddress, const nlohmann::json& calloutJSON);
 
 /**
  * @brief Determines the type of the path (FSI, I2C, etc) based

--- a/extensions/openpower-pels/entry_points.cpp
+++ b/extensions/openpower-pels/entry_points.cpp
@@ -25,6 +25,11 @@
 
 #include <format>
 
+#ifdef PEL_ENABLE_PHAL
+#include "libekb.H"
+#include "libpdbg.h"
+#endif
+
 namespace openpower
 {
 namespace pels
@@ -72,6 +77,19 @@ void pelStartup(internal::Manager& logManager)
         lg2::error("Failed to set PDBG_DTB: ({ERRNO})", "ERRNO",
                    strerror(errno));
     }
+
+    if (!pdbg_targets_init(NULL))
+    {
+        lg2::error("pdbg_targets_init failed");
+        return;
+    }
+
+    if (libekb_init())
+    {
+        lg2::error("libekb_init failed, skipping ffdc processing");
+        return;
+    }
+
 #endif
 }
 

--- a/extensions/openpower-pels/extended_user_data.cpp
+++ b/extensions/openpower-pels/extended_user_data.cpp
@@ -95,10 +95,9 @@ void ExtendedUserData::validate()
     }
 }
 
-std::optional<std::string>
-    ExtendedUserData::getJSON(uint8_t /*creatorID*/,
-                              const std::vector<std::string>& plugins
-                              [[maybe_unused]]) const
+std::optional<std::string> ExtendedUserData::getJSON(
+    uint8_t /*creatorID*/,
+    const std::vector<std::string>& plugins [[maybe_unused]]) const
 {
     // Use the creator ID value from the section.
 #ifdef PELTOOL

--- a/extensions/openpower-pels/fapi_data_process.cpp
+++ b/extensions/openpower-pels/fapi_data_process.cpp
@@ -251,9 +251,8 @@ static void addPlanarCallout(json& jsonCalloutDataList,
  * @return NULL
  *
  **/
-void processClockInfoErrorHelper(const FFDC& ffdc,
-                                 json& pelJSONFmtCalloutDataList,
-                                 FFDCData& ffdcUserData)
+void processClockInfoErrorHelper(
+    const FFDC& ffdc, json& pelJSONFmtCalloutDataList, FFDCData& ffdcUserData)
 {
     lg2::info("processClockInfoErrorHelper: FFDC Message[{FFDC_MSG}]",
               "FFDC_MSG", ffdc.message);
@@ -267,11 +266,11 @@ void processClockInfoErrorHelper(const FFDC& ffdc,
              ffdc.hwp_errorinfo.ffdcs_data.cend(),
              [&ffdcUserData](
                  const std::pair<std::string, std::string>& ele) -> void {
-        std::string keyWithPrefix("HWP_FFDC_");
-        keyWithPrefix.append(ele.first);
+                 std::string keyWithPrefix("HWP_FFDC_");
+                 keyWithPrefix.append(ele.first);
 
-        ffdcUserData.emplace_back(keyWithPrefix, ele.second);
-    });
+                 ffdcUserData.emplace_back(keyWithPrefix, ele.second);
+             });
     // get clock position information
     auto clk_pos = 0xFF; // Invalid position.
     for (auto& hwCallout : ffdc.hwp_errorinfo.hwcallouts)
@@ -288,14 +287,15 @@ void processClockInfoErrorHelper(const FFDC& ffdc,
              ffdc.hwp_errorinfo.cdg_targets.end(),
              [&ffdcUserData, &pelJSONFmtCalloutDataList,
               clk_pos](const CDG_Target& cdg_tgt) -> void {
-        json jsonCalloutData;
-        std::string pelPriority = "H";
-        jsonCalloutData["Priority"] = pelPriority; // Not used
-        jsonCalloutData["SymbolicFRU"] = "REFCLK" + std::to_string(clk_pos);
-        jsonCalloutData["Deconfigured"] = cdg_tgt.deconfigure;
-        jsonCalloutData["EntityPath"] = cdg_tgt.target_entity_path;
-        pelJSONFmtCalloutDataList.emplace_back(jsonCalloutData);
-    });
+                 json jsonCalloutData;
+                 std::string pelPriority = "H";
+                 jsonCalloutData["Priority"] = pelPriority; // Not used
+                 jsonCalloutData["SymbolicFRU"] =
+                     "REFCLK" + std::to_string(clk_pos);
+                 jsonCalloutData["Deconfigured"] = cdg_tgt.deconfigure;
+                 jsonCalloutData["EntityPath"] = cdg_tgt.target_entity_path;
+                 pelJSONFmtCalloutDataList.emplace_back(jsonCalloutData);
+             });
 }
 
 void convertFAPItoPELformat(FFDC& ffdc, json& pelJSONFmtCalloutDataList,
@@ -319,119 +319,126 @@ void convertFAPItoPELformat(FFDC& ffdc, json& pelJSONFmtCalloutDataList,
             ffdc.hwp_errorinfo.ffdcs_data.begin(),
             ffdc.hwp_errorinfo.ffdcs_data.end(),
             [&ffdcUserData](std::pair<std::string, std::string>& ele) -> void {
-            std::string keyWithPrefix("HWP_FFDC_");
-            keyWithPrefix.append(ele.first);
+                std::string keyWithPrefix("HWP_FFDC_");
+                keyWithPrefix.append(ele.first);
 
-            ffdcUserData.emplace_back(keyWithPrefix, ele.second);
-        });
+                ffdcUserData.emplace_back(keyWithPrefix, ele.second);
+            });
 
         // Adding hardware callout details
         int calloutCount = 0;
-        for_each(ffdc.hwp_errorinfo.hwcallouts.begin(),
-                 ffdc.hwp_errorinfo.hwcallouts.end(),
-                 [&ffdcUserData, &calloutCount, &pelJSONFmtCalloutDataList](
-                     const HWCallout& hwCallout) -> void {
-            calloutCount++;
-            std::stringstream keyPrefix;
-            keyPrefix << "HWP_HW_CO_" << std::setfill('0') << std::setw(2)
-                      << calloutCount << "_";
+        for_each(
+            ffdc.hwp_errorinfo.hwcallouts.begin(),
+            ffdc.hwp_errorinfo.hwcallouts.end(),
+            [&ffdcUserData, &calloutCount,
+             &pelJSONFmtCalloutDataList](const HWCallout& hwCallout) -> void {
+                calloutCount++;
+                std::stringstream keyPrefix;
+                keyPrefix << "HWP_HW_CO_" << std::setfill('0') << std::setw(2)
+                          << calloutCount << "_";
 
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("HW_ID"), hwCallout.hwid);
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("HW_ID"),
+                    hwCallout.hwid);
 
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("PRIORITY"),
-                hwCallout.callout_priority);
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("PRIORITY"),
+                    hwCallout.callout_priority);
 
-            phal::TargetInfo targetInfo;
-            phal::getTgtReqAttrsVal(hwCallout.target_entity_path, targetInfo);
+                phal::TargetInfo targetInfo;
+                phal::getTgtReqAttrsVal(hwCallout.target_entity_path,
+                                        targetInfo);
 
-            std::string locationCode = std::string(targetInfo.locationCode);
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("LOC_CODE"), locationCode);
+                std::string locationCode = std::string(targetInfo.locationCode);
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("LOC_CODE"),
+                    locationCode);
 
-            std::string physPath = std::string(targetInfo.physDevPath);
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("PHYS_PATH"), physPath);
+                std::string physPath = std::string(targetInfo.physDevPath);
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("PHYS_PATH"), physPath);
 
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("CLK_POS"),
-                std::to_string(hwCallout.clkPos));
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("CLK_POS"),
+                    std::to_string(hwCallout.clkPos));
 
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("CALLOUT_PLANAR"),
-                (hwCallout.isPlanarCallout == true ? "true" : "false"));
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("CALLOUT_PLANAR"),
+                    (hwCallout.isPlanarCallout == true ? "true" : "false"));
 
-            std::string pelPriority =
-                getPelPriority(hwCallout.callout_priority);
+                std::string pelPriority =
+                    getPelPriority(hwCallout.callout_priority);
 
-            if (hwCallout.isPlanarCallout)
-            {
-                addPlanarCallout(pelJSONFmtCalloutDataList, pelPriority);
-            }
-        });
+                if (hwCallout.isPlanarCallout)
+                {
+                    addPlanarCallout(pelJSONFmtCalloutDataList, pelPriority);
+                }
+            });
 
         // Adding CDG (callout, deconfigure and guard) targets details
         calloutCount = 0;
-        for_each(ffdc.hwp_errorinfo.cdg_targets.begin(),
-                 ffdc.hwp_errorinfo.cdg_targets.end(),
-                 [&ffdcUserData, &calloutCount, &pelJSONFmtCalloutDataList](
-                     const CDG_Target& cdg_tgt) -> void {
-            calloutCount++;
-            std::stringstream keyPrefix;
-            keyPrefix << "HWP_CDG_TGT_" << std::setfill('0') << std::setw(2)
-                      << calloutCount << "_";
+        for_each(
+            ffdc.hwp_errorinfo.cdg_targets.begin(),
+            ffdc.hwp_errorinfo.cdg_targets.end(),
+            [&ffdcUserData, &calloutCount,
+             &pelJSONFmtCalloutDataList](const CDG_Target& cdg_tgt) -> void {
+                calloutCount++;
+                std::stringstream keyPrefix;
+                keyPrefix << "HWP_CDG_TGT_" << std::setfill('0') << std::setw(2)
+                          << calloutCount << "_";
 
-            phal::TargetInfo targetInfo;
-            targetInfo.deconfigure = cdg_tgt.deconfigure;
+                phal::TargetInfo targetInfo;
+                targetInfo.deconfigure = cdg_tgt.deconfigure;
 
-            phal::getTgtReqAttrsVal(cdg_tgt.target_entity_path, targetInfo);
+                phal::getTgtReqAttrsVal(cdg_tgt.target_entity_path, targetInfo);
 
-            std::string locationCode = std::string(targetInfo.locationCode);
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("LOC_CODE"), locationCode);
-            std::string physPath = std::string(targetInfo.physDevPath);
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("PHYS_PATH"), physPath);
+                std::string locationCode = std::string(targetInfo.locationCode);
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("LOC_CODE"),
+                    locationCode);
+                std::string physPath = std::string(targetInfo.physDevPath);
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("PHYS_PATH"), physPath);
 
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("CO_REQ"),
-                (cdg_tgt.callout == true ? "true" : "false"));
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("CO_REQ"),
+                    (cdg_tgt.callout == true ? "true" : "false"));
 
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("CO_PRIORITY"),
-                cdg_tgt.callout_priority);
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("CO_PRIORITY"),
+                    cdg_tgt.callout_priority);
 
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("DECONF_REQ"),
-                (cdg_tgt.deconfigure == true ? "true" : "false"));
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("DECONF_REQ"),
+                    (cdg_tgt.deconfigure == true ? "true" : "false"));
 
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("GUARD_REQ"),
-                (cdg_tgt.guard == true ? "true" : "false"));
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("GUARD_REQ"),
+                    (cdg_tgt.guard == true ? "true" : "false"));
 
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("GUARD_TYPE"),
-                cdg_tgt.guard_type);
+                ffdcUserData.emplace_back(
+                    std::string(keyPrefix.str()).append("GUARD_TYPE"),
+                    cdg_tgt.guard_type);
 
-            json jsonCalloutData;
-            jsonCalloutData["LocationCode"] = locationCode;
-            std::string pelPriority = getPelPriority(cdg_tgt.callout_priority);
-            jsonCalloutData["Priority"] = pelPriority;
+                json jsonCalloutData;
+                jsonCalloutData["LocationCode"] = locationCode;
+                std::string pelPriority =
+                    getPelPriority(cdg_tgt.callout_priority);
+                jsonCalloutData["Priority"] = pelPriority;
 
-            if (targetInfo.mruId != 0)
-            {
-                jsonCalloutData["MRUs"] = json::array({
-                    {{"ID", targetInfo.mruId}, {"Priority", pelPriority}},
-                });
-            }
-            jsonCalloutData["Deconfigured"] = cdg_tgt.deconfigure;
-            jsonCalloutData["Guarded"] = cdg_tgt.guard;
-            jsonCalloutData["GuardType"] = cdg_tgt.guard_type;
-            jsonCalloutData["EntityPath"] = cdg_tgt.target_entity_path;
+                if (targetInfo.mruId != 0)
+                {
+                    jsonCalloutData["MRUs"] = json::array({
+                        {{"ID", targetInfo.mruId}, {"Priority", pelPriority}},
+                    });
+                }
+                jsonCalloutData["Deconfigured"] = cdg_tgt.deconfigure;
+                jsonCalloutData["Guarded"] = cdg_tgt.guard;
+                jsonCalloutData["GuardType"] = cdg_tgt.guard_type;
+                jsonCalloutData["EntityPath"] = cdg_tgt.target_entity_path;
 
-            pelJSONFmtCalloutDataList.emplace_back(jsonCalloutData);
-        });
+                pelJSONFmtCalloutDataList.emplace_back(jsonCalloutData);
+            });
 
         // Adding procedure callout
         calloutCount = 0;
@@ -439,23 +446,23 @@ void convertFAPItoPELformat(FFDC& ffdc, json& pelJSONFmtCalloutDataList,
                  ffdc.hwp_errorinfo.procedures_callout.end(),
                  [&ffdcUserData, &calloutCount, &pelJSONFmtCalloutDataList](
                      const ProcedureCallout& procCallout) -> void {
-            calloutCount++;
-            std::stringstream keyPrefix;
-            keyPrefix << "HWP_PROC_CO_" << std::setfill('0') << std::setw(2)
-                      << calloutCount << "_";
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("PRIORITY"),
-                procCallout.callout_priority);
-            ffdcUserData.emplace_back(
-                std::string(keyPrefix.str()).append("MAINT_PROCEDURE"),
-                procCallout.proc_callout);
-            json jsonCalloutData;
-            jsonCalloutData["Procedure"] = procCallout.proc_callout;
-            std::string pelPriority =
-                getPelPriority(procCallout.callout_priority);
-            jsonCalloutData["Priority"] = pelPriority;
-            pelJSONFmtCalloutDataList.emplace_back(jsonCalloutData);
-        });
+                     calloutCount++;
+                     std::stringstream keyPrefix;
+                     keyPrefix << "HWP_PROC_CO_" << std::setfill('0')
+                               << std::setw(2) << calloutCount << "_";
+                     ffdcUserData.emplace_back(
+                         std::string(keyPrefix.str()).append("PRIORITY"),
+                         procCallout.callout_priority);
+                     ffdcUserData.emplace_back(
+                         std::string(keyPrefix.str()).append("MAINT_PROCEDURE"),
+                         procCallout.proc_callout);
+                     json jsonCalloutData;
+                     jsonCalloutData["Procedure"] = procCallout.proc_callout;
+                     std::string pelPriority =
+                         getPelPriority(procCallout.callout_priority);
+                     jsonCalloutData["Priority"] = pelPriority;
+                     pelJSONFmtCalloutDataList.emplace_back(jsonCalloutData);
+                 });
     }
     else if ((ffdc.ffdc_type != FFDC_TYPE_NONE) &&
              (ffdc.ffdc_type != FFDC_TYPE_UNSUPPORTED))

--- a/extensions/openpower-pels/host_notifier.cpp
+++ b/extensions/openpower-pels/host_notifier.cpp
@@ -25,16 +25,15 @@ const size_t maxRetryAttempts = 15;
 
 HostNotifier::HostNotifier(Repository& repo, DataInterfaceBase& dataIface,
                            std::unique_ptr<HostInterface> hostIface) :
-    _repo(repo),
-    _dataIface(dataIface), _hostIface(std::move(hostIface)),
+    _repo(repo), _dataIface(dataIface), _hostIface(std::move(hostIface)),
     _retryTimer(_hostIface->getEvent(),
                 std::bind(std::mem_fn(&HostNotifier::retryTimerExpired), this)),
     _hostFullTimer(
         _hostIface->getEvent(),
         std::bind(std::mem_fn(&HostNotifier::hostFullTimerExpired), this)),
-    _hostUpTimer(
-        _hostIface->getEvent(),
-        std::bind(std::mem_fn(&HostNotifier::hostUpTimerExpired), this))
+    _hostUpTimer(_hostIface->getEvent(),
+                 std::bind(std::mem_fn(&HostNotifier::hostUpTimerExpired),
+                           this))
 {
     // Subscribe to be told about new PELs.
     _repo.subscribeToAdds(subscriptionName,

--- a/extensions/openpower-pels/journal.cpp
+++ b/extensions/openpower-pels/journal.cpp
@@ -68,8 +68,8 @@ void Journal::sync() const
     }
 }
 
-std::vector<std::string> Journal::getMessages(const std::string& syslogID,
-                                              size_t maxMessages) const
+std::vector<std::string>
+    Journal::getMessages(const std::string& syslogID, size_t maxMessages) const
 {
     // The message registry JSON schema will also fail if a zero is in the JSON
     if (0 == maxMessages)
@@ -83,8 +83,8 @@ std::vector<std::string> Journal::getMessages(const std::string& syslogID,
     int rc = sd_journal_open(&journal, SD_JOURNAL_LOCAL_ONLY);
     if (rc < 0)
     {
-        throw std::runtime_error{std::string{"Failed to open journal: "} +
-                                 strerror(-rc)};
+        throw std::runtime_error{
+            std::string{"Failed to open journal: "} + strerror(-rc)};
     }
 
     JournalCloser closer{journal};

--- a/extensions/openpower-pels/journal.hpp
+++ b/extensions/openpower-pels/journal.hpp
@@ -30,8 +30,8 @@ class JournalBase
      *
      * @return The messages
      */
-    virtual std::vector<std::string> getMessages(const std::string& syslogID,
-                                                 size_t maxMessages) const = 0;
+    virtual std::vector<std::string>
+        getMessages(const std::string& syslogID, size_t maxMessages) const = 0;
 
     /**
      * @brief Call journalctl --sync to write unwritten journal data to disk

--- a/extensions/openpower-pels/json_utils.cpp
+++ b/extensions/openpower-pels/json_utils.cpp
@@ -176,8 +176,8 @@ std::unique_ptr<char[]> dumpHex(const void* data, size_t size,
 void jsonInsert(std::string& jsonStr, const std::string& fieldName,
                 const std::string& fieldValue, uint8_t indentCount)
 {
-    const int8_t spacesToAppend = colAlign - (indentCount * indentLevel) -
-                                  fieldName.length() - 3;
+    const int8_t spacesToAppend =
+        colAlign - (indentCount * indentLevel) - fieldName.length() - 3;
     const std::string jsonIndent(indentCount * indentLevel, 0x20);
     jsonStr.append(jsonIndent + "\"" + fieldName + "\":");
     if (spacesToAppend >= 0)
@@ -215,8 +215,8 @@ void jsonInsertArray(std::string& jsonStr, const std::string& fieldName,
     }
     else
     {
-        const int8_t spacesToAppend = colAlign - (indentCount * indentLevel) -
-                                      fieldName.length() - 3;
+        const int8_t spacesToAppend =
+            colAlign - (indentCount * indentLevel) - fieldName.length() - 3;
         jsonStr.append(jsonIndent + "\"" + fieldName + "\":");
         if (spacesToAppend > 0)
         {
@@ -252,14 +252,14 @@ std::string trimEnd(std::string s)
  * @param[in] creatorID - The creator ID for the PEL
  * @return optional<string> - The comp name, or std::nullopt
  */
-static std::optional<std::string> lookupComponentName(uint16_t compID,
-                                                      char creatorID)
+static std::optional<std::string>
+    lookupComponentName(uint16_t compID, char creatorID)
 {
     static std::map<char, nlohmann::json> jsonCache;
     nlohmann::json jsonData;
     nlohmann::json* jsonPtr = &jsonData;
-    std::filesystem::path filename{std::string{creatorID} +
-                                   "_component_ids.json"};
+    std::filesystem::path filename{
+        std::string{creatorID} + "_component_ids.json"};
     filename = getPELReadOnlyDataPath() / filename;
 
     auto jsonIt = jsonCache.find(creatorID);

--- a/extensions/openpower-pels/manager.cpp
+++ b/extensions/openpower-pels/manager.cpp
@@ -338,12 +338,11 @@ PelFFDC Manager::convertToPelFFDC(const FFDCEntries& ffdc)
     return pelFFDC;
 }
 
-void Manager::createPEL(const std::string& message, uint32_t obmcLogID,
-                        uint64_t timestamp,
-                        phosphor::logging::Entry::Level severity,
-                        const std::vector<std::string>& additionalData,
-                        const std::vector<std::string>& /*associations*/,
-                        const FFDCEntries& ffdc)
+void Manager::createPEL(
+    const std::string& message, uint32_t obmcLogID, uint64_t timestamp,
+    phosphor::logging::Entry::Level severity,
+    const std::vector<std::string>& additionalData,
+    const std::vector<std::string>& /*associations*/, const FFDCEntries& ffdc)
 {
     auto entry = _registry.lookup(message, rg::LookupType::name);
     auto pelFFDC = convertToPelFFDC(ffdc);
@@ -860,8 +859,8 @@ void Manager::updateDBusSeverity(const openpower::pels::PEL& pel)
     auto entryN = _logManager.entries.find(pel.obmcLogID());
     if (entryN != _logManager.entries.end())
     {
-        auto newSeverity = fixupLogSeverity(entryN->second->severity(),
-                                            sevType);
+        auto newSeverity =
+            fixupLogSeverity(entryN->second->severity(), sevType);
         if (newSeverity)
         {
             lg2::info("Changing event log {ID} severity from {OLD} "
@@ -1001,8 +1000,8 @@ void Manager::updateProgressSRC(
             // Read bytes from offset [40-47] e.g. BD8D1001
             for (int i = 0; i < 8; i++)
             {
-                srcRefCode |= (static_cast<uint64_t>(asciiSRC[40 + i])
-                               << (8 * i));
+                srcRefCode |=
+                    (static_cast<uint64_t>(asciiSRC[40 + i]) << (8 * i));
             }
 
             try
@@ -1084,8 +1083,8 @@ void Manager::hardwarePresent(const std::string& locationCode)
 {
     Repository::PELUpdateFunc handlePowerThermalHardwarePresent =
         [locationCode](openpower::pels::PEL& pel) {
-        return Manager::clearPowerThermalDeconfigFlag(locationCode, pel);
-    };
+            return Manager::clearPowerThermalDeconfigFlag(locationCode, pel);
+        };
 
     // If the PEL was created by the BMC and has the deconfig flag set,
     // it's a candidate to have the deconfig flag cleared.

--- a/extensions/openpower-pels/manager.hpp
+++ b/extensions/openpower-pels/manager.hpp
@@ -51,9 +51,8 @@ class Manager : public PELInterface
             std::unique_ptr<DataInterfaceBase> dataIface,
             EventLogger::LogFunction creatorFunc,
             std::unique_ptr<JournalBase> journal) :
-        PELInterface(logManager.getBus(), OBJ_LOGGING),
-        _logManager(logManager), _eventLogger(std::move(creatorFunc)),
-        _repo(getPELRepoPath()),
+        PELInterface(logManager.getBus(), OBJ_LOGGING), _logManager(logManager),
+        _eventLogger(std::move(creatorFunc)), _repo(getPELRepoPath()),
         _registry(getPELReadOnlyDataPath() / message::registryFileName),
         _event(sdeventplus::Event::get_default()),
         _dataIface(std::move(dataIface)), _journal(std::move(journal))

--- a/extensions/openpower-pels/meson.build
+++ b/extensions/openpower-pels/meson.build
@@ -68,6 +68,7 @@ libpel_sources = files(
     'severity.cpp',
     'user_header.cpp',
     'temporary_file.cpp',
+    '../../util.cpp',
     extra_sources,
 )
 

--- a/extensions/openpower-pels/mru.cpp
+++ b/extensions/openpower-pels/mru.cpp
@@ -41,9 +41,9 @@ MRU::MRU(Stream& pel)
         _mrus.push_back(std::move(mru));
     }
 
-    size_t actualSize = sizeof(_type) + sizeof(_size) + sizeof(_flags) +
-                        sizeof(_reserved4B) +
-                        (sizeof(MRUCallout) * _mrus.size());
+    size_t actualSize =
+        sizeof(_type) + sizeof(_size) + sizeof(_flags) + sizeof(_reserved4B) +
+        (sizeof(MRUCallout) * _mrus.size());
     if (_size != actualSize)
     {
         lg2::warning(

--- a/extensions/openpower-pels/pel.cpp
+++ b/extensions/openpower-pels/pel.cpp
@@ -63,18 +63,18 @@ PEL::PEL(const message::Entry& regEntry, uint32_t obmcLogID, uint64_t timestamp,
 #ifdef PEL_ENABLE_PHAL
     // Add sbe ffdc processed data into ffdcfiles.
     namespace sbe = openpower::pels::sbe;
-    auto processReq = std::any_of(ffdcFiles.begin(), ffdcFiles.end(),
-                                  [](const auto& file) {
-        return file.format == UserDataFormat::custom &&
-               file.subType == sbe::sbeFFDCSubType;
-    });
+    auto processReq =
+        std::any_of(ffdcFiles.begin(), ffdcFiles.end(), [](const auto& file) {
+            return file.format == UserDataFormat::custom &&
+                   file.subType == sbe::sbeFFDCSubType;
+        });
     // sbeFFDC can't be destroyed until the end of the PEL constructor
     // because it needs to keep around the FFDC Files to be used below.
     std::unique_ptr<sbe::SbeFFDC> sbeFFDCPtr;
     if (processReq)
     {
-        sbeFFDCPtr = std::make_unique<sbe::SbeFFDC>(additionalData,
-                                                    ffdcFilesIn);
+        sbeFFDCPtr =
+            std::make_unique<sbe::SbeFFDC>(additionalData, ffdcFilesIn);
         const auto& sbeFFDCFiles = sbeFFDCPtr->getSbeFFDC();
         ffdcFiles.insert(ffdcFiles.end(), sbeFFDCFiles.begin(),
                          sbeFFDCFiles.end());
@@ -109,8 +109,8 @@ PEL::PEL(const message::Entry& regEntry, uint32_t obmcLogID, uint64_t timestamp,
         }
     }
 
-    auto src = std::make_unique<SRC>(regEntry, additionalData, callouts,
-                                     dataIface);
+    auto src =
+        std::make_unique<SRC>(regEntry, additionalData, callouts, dataIface);
 
     if (!src->getDebugData().empty())
     {
@@ -307,11 +307,11 @@ size_t PEL::size() const
 
 std::optional<SRC*> PEL::primarySRC() const
 {
-    auto src = std::find_if(_optionalSections.begin(), _optionalSections.end(),
-                            [](auto& section) {
-        return section->header().id ==
-               static_cast<uint16_t>(SectionID::primarySRC);
-    });
+    auto src = std::find_if(
+        _optionalSections.begin(), _optionalSections.end(), [](auto& section) {
+            return section->header().id ==
+                   static_cast<uint16_t>(SectionID::primarySRC);
+        });
     if (src != _optionalSections.end())
     {
         return static_cast<SRC*>(src->get());
@@ -327,19 +327,18 @@ void PEL::checkRulesAndFix()
     // assume the user knows what they are doing.
     if (_uh->actionFlags() == actionFlagsDefault)
     {
-        auto [actionFlags, eventType] = pel_rules::check(0, _uh->eventType(),
-                                                         _uh->severity());
+        auto [actionFlags, eventType] =
+            pel_rules::check(0, _uh->eventType(), _uh->severity());
 
         _uh->setActionFlags(actionFlags);
         _uh->setEventType(eventType);
     }
 }
 
-void PEL::printSectionInJSON(const Section& section, std::string& buf,
-                             std::map<uint16_t, size_t>& pluralSections,
-                             message::Registry& registry,
-                             const std::vector<std::string>& plugins,
-                             uint8_t creatorID) const
+void PEL::printSectionInJSON(
+    const Section& section, std::string& buf,
+    std::map<uint16_t, size_t>& pluralSections, message::Registry& registry,
+    const std::vector<std::string>& plugins, uint8_t creatorID) const
 {
     char tmpB[5];
     uint8_t id[] = {static_cast<uint8_t>(section.header().id >> 8),
@@ -553,11 +552,12 @@ void PEL::updateSysInfoInExtendedUserDataSection(
     if (_ph->creatorID() == static_cast<uint8_t>(CreatorID::hostboot))
     {
         // Get the ED section from PEL
-        auto op = std::find_if(_optionalSections.begin(),
-                               _optionalSections.end(), [](auto& section) {
-            return section->header().id ==
-                   static_cast<uint16_t>(SectionID::extUserData);
-        });
+        auto op = std::find_if(
+            _optionalSections.begin(), _optionalSections.end(),
+            [](auto& section) {
+                return section->header().id ==
+                       static_cast<uint16_t>(SectionID::extUserData);
+            });
 
         // Check for ED section found and its not the last section of PEL
         if (op != _optionalSections.end())
@@ -846,10 +846,9 @@ void addBMCUptime(nlohmann::json& json, const DataInterfaceBase& dataIface)
     json["BMCLoad"] = dataIface.getBMCLoadAvg();
 }
 
-std::unique_ptr<UserData>
-    makeSysInfoUserDataSection(const AdditionalData& ad,
-                               const DataInterfaceBase& dataIface,
-                               bool addUptime)
+std::unique_ptr<UserData> makeSysInfoUserDataSection(
+    const AdditionalData& ad, const DataInterfaceBase& dataIface,
+    bool addUptime)
 {
     nlohmann::json json;
 
@@ -916,8 +915,8 @@ std::vector<uint8_t> readFD(int fd)
     return data;
 }
 
-std::unique_ptr<UserData> makeFFDCuserDataSection(uint16_t componentID,
-                                                  const PelFFDCfile& file)
+std::unique_ptr<UserData>
+    makeFFDCuserDataSection(uint16_t componentID, const PelFFDCfile& file)
 {
     auto data = readFD(file.fd);
 

--- a/extensions/openpower-pels/pel.hpp
+++ b/extensions/openpower-pels/pel.hpp
@@ -382,11 +382,10 @@ class PEL
      * @param[in] plugins - Vector of strings of plugins found in filesystem
      * @param[in] creatorID - Creator Subsystem ID (only for UserData section)
      */
-    void printSectionInJSON(const Section& section, std::string& buf,
-                            std::map<uint16_t, size_t>& pluralSections,
-                            message::Registry& registry,
-                            const std::vector<std::string>& plugins,
-                            uint8_t creatorID = 0) const;
+    void printSectionInJSON(
+        const Section& section, std::string& buf,
+        std::map<uint16_t, size_t>& pluralSections, message::Registry& registry,
+        const std::vector<std::string>& plugins, uint8_t creatorID = 0) const;
 
     /**
      * @brief Returns any callout JSON found in the FFDC files.
@@ -470,10 +469,9 @@ std::unique_ptr<UserData> makeADUserDataSection(const AdditionalData& ad);
  *
  * @return std::unique_ptr<UserData> - The section
  */
-std::unique_ptr<UserData>
-    makeSysInfoUserDataSection(const AdditionalData& ad,
-                               const DataInterfaceBase& dataIface,
-                               bool addUptime = true);
+std::unique_ptr<UserData> makeSysInfoUserDataSection(
+    const AdditionalData& ad, const DataInterfaceBase& dataIface,
+    bool addUptime = true);
 
 /**
  * @brief Reads data from an opened file descriptor.
@@ -491,8 +489,8 @@ std::vector<uint8_t> readFD(int fd);
  * @param[in] componentID - The component ID of the PEL creator
  * @param[in] file - The FFDC file information
  */
-std::unique_ptr<UserData> makeFFDCuserDataSection(uint16_t componentID,
-                                                  const PelFFDCfile& file);
+std::unique_ptr<UserData>
+    makeFFDCuserDataSection(uint16_t componentID, const PelFFDCfile& file);
 
 /**
  * @brief Flattens a vector of strings into a vector of bytes suitable

--- a/extensions/openpower-pels/pel_entry.hpp
+++ b/extensions/openpower-pels/pel_entry.hpp
@@ -32,8 +32,7 @@ class PELEntry : public PELEntryIface
     PELEntry(sdbusplus::bus_t& bus, const std::string& path,
              const std::map<std::string, PropertiesVariant>& prop, uint32_t id,
              Repository* repo) :
-        PELEntryIface(bus, path.c_str(), prop, true),
-        _obmcId(id), _repo(repo)
+        PELEntryIface(bus, path.c_str(), prop, true), _obmcId(id), _repo(repo)
     {}
 
     /** @brief Update managementSystemAck flag.

--- a/extensions/openpower-pels/pel_values.cpp
+++ b/extensions/openpower-pels/pel_values.cpp
@@ -252,8 +252,8 @@ PELValues::const_iterator findByValue(uint32_t value, const PELValues& fields)
 {
     return std::find_if(fields.begin(), fields.end(),
                         [value](const auto& entry) {
-        return value == std::get<fieldValuePos>(entry);
-    });
+                            return value == std::get<fieldValuePos>(entry);
+                        });
 }
 
 PELValues::const_iterator findByName(const std::string& name,
@@ -262,8 +262,8 @@ PELValues::const_iterator findByName(const std::string& name,
 {
     return std::find_if(fields.begin(), fields.end(),
                         [&name](const auto& entry) {
-        return name == std::get<registryNamePos>(entry);
-    });
+                            return name == std::get<registryNamePos>(entry);
+                        });
 }
 
 /**
@@ -357,13 +357,13 @@ std::vector<std::string> getValuesBitwise(uint16_t value,
                                           const pel_values::PELValues& table)
 {
     std::vector<std::string> foundValues;
-    std::for_each(table.begin(), table.end(),
-                  [&value, &foundValues](const auto& entry) {
-        if (value & std::get<fieldValuePos>(entry))
-        {
-            foundValues.push_back(std::get<descriptionPos>(entry));
-        }
-    });
+    std::for_each(
+        table.begin(), table.end(), [&value, &foundValues](const auto& entry) {
+            if (value & std::get<fieldValuePos>(entry))
+            {
+                foundValues.push_back(std::get<descriptionPos>(entry));
+            }
+        });
     return foundValues;
 }
 

--- a/extensions/openpower-pels/phal_service_actions.cpp
+++ b/extensions/openpower-pels/phal_service_actions.cpp
@@ -192,12 +192,6 @@ void createDeconfigRecords(const nlohmann::json& jsonCallouts,
             ATTR_PHYS_BIN_PATH_Type physBinPath;
             std::copy(entityPath.begin(), entityPath.end(), physBinPath);
             // libphal api to deconfigure the target
-            if (!pdbg_targets_init(NULL))
-            {
-                lg2::error(
-                    "pdbg_targets_init failed, skipping deconfig record update");
-                return;
-            }
             openpower::phal::pdbg::deconfigureTgt(physBinPath, plid);
         }
         catch (const std::exception& e)

--- a/extensions/openpower-pels/pldm_interface.cpp
+++ b/extensions/openpower-pels/pldm_interface.cpp
@@ -143,9 +143,9 @@ void PLDMInterface::freeIID()
 
     if (rc == -EINVAL)
     {
-        throw std::runtime_error("Instance ID " + std::to_string(*_instanceID) +
-                                 " for TID " + std::to_string(_eid) +
-                                 " was not previously allocated");
+        throw std::runtime_error(
+            "Instance ID " + std::to_string(*_instanceID) + " for TID " +
+            std::to_string(_eid) + " was not previously allocated");
     }
     else if (rc)
     {

--- a/extensions/openpower-pels/registry.cpp
+++ b/extensions/openpower-pels/registry.cpp
@@ -549,9 +549,8 @@ RegistryCallout makeRegistryCallout(const nlohmann::json& json)
  *
  * @return std::vector<RegistryCallout> - The callouts to use
  */
-std::vector<RegistryCallout>
-    getCalloutsWithoutAD(const nlohmann::json& json,
-                         const std::vector<std::string>& systemNames)
+std::vector<RegistryCallout> getCalloutsWithoutAD(
+    const nlohmann::json& json, const std::vector<std::string>& systemNames)
 {
     std::vector<RegistryCallout> calloutEntries;
 
@@ -605,10 +604,9 @@ std::vector<RegistryCallout>
  *
  * @return std::vector<RegistryCallout> - The callouts to use
  */
-std::vector<RegistryCallout>
-    getCalloutsUsingAD(const nlohmann::json& json,
-                       const std::vector<std::string>& systemNames,
-                       const AdditionalData& additionalData)
+std::vector<RegistryCallout> getCalloutsUsingAD(
+    const nlohmann::json& json, const std::vector<std::string>& systemNames,
+    const AdditionalData& additionalData)
 {
     // This indicates which AD field we'll be using
     auto keyName = json["ADName"].get<std::string>();
@@ -630,10 +628,10 @@ std::vector<RegistryCallout>
     const auto& callouts = json["CalloutsWithTheirADValues"];
 
     // find the entry with that AD value
-    auto it = std::find_if(callouts.begin(), callouts.end(),
-                           [adValue](const nlohmann::json& j) {
-        return *adValue == j["ADValue"].get<std::string>();
-    });
+    auto it = std::find_if(
+        callouts.begin(), callouts.end(), [adValue](const nlohmann::json& j) {
+            return *adValue == j["ADValue"].get<std::string>();
+        });
 
     if (it == callouts.end())
     {
@@ -728,13 +726,14 @@ std::optional<Entry> Registry::lookup(const std::string& name, LookupType type,
     auto& reg = (_registry) ? _registry : registryTmp;
     const auto& registry = reg.value();
     // Find an entry with this name in the PEL array.
-    auto e = std::find_if(registry["PELs"].begin(), registry["PELs"].end(),
-                          [&name, &type](const nlohmann::json& j) {
-        return ((name == j.at("Name").get<std::string>() &&
-                 type == LookupType::name) ||
-                (name == j.at("SRC").at("ReasonCode").get<std::string>() &&
-                 type == LookupType::reasonCode));
-    });
+    auto e = std::find_if(
+        registry["PELs"].begin(), registry["PELs"].end(),
+        [&name, &type](const nlohmann::json& j) {
+            return ((name == j.at("Name").get<std::string>() &&
+                     type == LookupType::name) ||
+                    (name == j.at("SRC").at("ReasonCode").get<std::string>() &&
+                     type == LookupType::reasonCode));
+        });
 
     if (e != registry["PELs"].end())
     {
@@ -801,8 +800,8 @@ std::optional<Entry> Registry::lookup(const std::string& name, LookupType type,
 
             if (src.contains("Words6To9"))
             {
-                entry.src.hexwordADFields = helper::getSRCHexwordFields(src,
-                                                                        name);
+                entry.src.hexwordADFields =
+                    helper::getSRCHexwordFields(src, name);
             }
 
             if (src.contains("SymptomIDFields"))

--- a/extensions/openpower-pels/registry.hpp
+++ b/extensions/openpower-pels/registry.hpp
@@ -265,8 +265,7 @@ class Registry
      */
     explicit Registry(const std::filesystem::path& registryFile,
                       bool loadCallouts) :
-        _registryFile(registryFile),
-        _loadCallouts(loadCallouts)
+        _registryFile(registryFile), _loadCallouts(loadCallouts)
     {}
 
     /**

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -4306,7 +4306,7 @@
         },
 
         {
-            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperaturePerfLossHigh",
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperaturePerformanceLossHigh",
             "Subsystem": "power",
             "ComponentID": "0x2800",
             "Severity": "predictive",
@@ -4359,7 +4359,7 @@
         },
 
         {
-            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperaturePerfLossHighClear",
+            "Name": "xyz.openbmc_project.Sensor.Threshold.Error.TemperaturePerformanceLossHighClear",
             "Subsystem": "power",
             "ComponentID": "0x2800",
             "Severity": "non_error",

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6093,6 +6093,48 @@
             }
         },
         {
+            "Name": "xyz.openbmc_project.PLDM.Error.ReportResourceDumpFail.NewFileAvailableRequest",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x6000",
+            "Severity": "predictive",
+            "SRC": {
+                "ReasonCode": "0x6027",
+                "Words6To9": {}
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "BMC0001" }
+                    ]
+                }
+            ],
+            "Documentation": {
+                "Description": "Failed to send NewFileAvailable request to remote terminus.",
+                "Message": "Failed to send NewFileAvailable request to remote terminus."
+            }
+        },
+        {
+            "Name": "xyz.openbmc_project.PLDM.Error.ReportResourceDumpFail.DecodeNewFileResp",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x6000",
+            "Severity": "predictive",
+            "SRC": {
+                "ReasonCode": "0x6028",
+                "Words6To9": {}
+            },
+            "Callouts": [
+                {
+                    "CalloutList": [
+                        { "Priority": "high", "Procedure": "BMC0001" }
+                    ]
+                }
+            ],
+            "Documentation": {
+                "Description": "Failed to decode NewFileAvailable response",
+                "Message": "Failed to decode NewFileAvailable response"
+            }
+        },
+        {
             "Name": "xyz.openbmc_project.Memory.MemoryECC.Error.CEThresholdReached",
             "Subsystem": "cec_hardware",
             "ComponentID": "0xF300",

--- a/extensions/openpower-pels/repository.cpp
+++ b/extensions/openpower-pels/repository.cpp
@@ -60,9 +60,8 @@ size_t getFileDiskSize(const std::filesystem::path& file)
 
 Repository::Repository(const std::filesystem::path& basePath, size_t repoSize,
                        size_t maxNumPELs) :
-    _logPath(basePath / "logs"),
-    _maxRepoSize(repoSize), _maxNumPELs(maxNumPELs),
-    _archivePath(basePath / "logs" / "archive")
+    _logPath(basePath / "logs"), _maxRepoSize(repoSize),
+    _maxNumPELs(maxNumPELs), _archivePath(basePath / "logs" / "archive")
 {
     if (!fs::exists(_logPath))
     {
@@ -495,8 +494,8 @@ bool Repository::updatePEL(const fs::path& path, PELUpdateFunc updateFunc)
 bool Repository::isServiceableSev(const PELAttributes& pel)
 {
     auto sevType = static_cast<SeverityType>(pel.severity & 0xF0);
-    auto sevPVEntry = pel_values::findByValue(pel.severity,
-                                              pel_values::severityValues);
+    auto sevPVEntry =
+        pel_values::findByValue(pel.severity, pel_values::severityValues);
     std::string sevName = std::get<pel_values::registryNamePos>(*sevPVEntry);
 
     bool check1 = (sevType == SeverityType::predictive) ||
@@ -593,18 +592,19 @@ std::vector<Repository::AttributesReference>
 {
     std::vector<Repository::AttributesReference> attributes;
 
-    std::for_each(
-        _pelAttributes.begin(), _pelAttributes.end(),
-        [&attributes](auto& pelEntry) { attributes.push_back(pelEntry); });
+    std::for_each(_pelAttributes.begin(), _pelAttributes.end(),
+                  [&attributes](auto& pelEntry) {
+                      attributes.push_back(pelEntry);
+                  });
 
     std::sort(attributes.begin(), attributes.end(),
               [order](const auto& left, const auto& right) {
-        if (order == SortOrder::ascending)
-        {
-            return left.get().second.path < right.get().second.path;
-        }
-        return left.get().second.path > right.get().second.path;
-    });
+                  if (order == SortOrder::ascending)
+                  {
+                      return left.get().second.path < right.get().second.path;
+                  }
+                  return left.get().second.path > right.get().second.path;
+              });
 
     return attributes;
 }
@@ -721,16 +721,16 @@ void Repository::removePELs(const IsOverLimitFunc& isOverLimit,
     //   Pass 4: delete all PELs
     static const std::vector<std::function<bool(const PELAttributes& pel)>>
         stateChecks{[](const auto& pel) {
-        return pel.hmcState == TransmissionState::acked;
-    },
+                        return pel.hmcState == TransmissionState::acked;
+                    },
 
                     [](const auto& pel) {
-        return pel.hostState == TransmissionState::acked;
-    },
+                        return pel.hostState == TransmissionState::acked;
+                    },
 
                     [](const auto& pel) {
-        return pel.hostState == TransmissionState::sent;
-    },
+                        return pel.hostState == TransmissionState::sent;
+                    },
 
                     [](const auto& /*pel*/) { return true; }};
 

--- a/extensions/openpower-pels/repository.hpp
+++ b/extensions/openpower-pels/repository.hpp
@@ -46,8 +46,7 @@ class Repository
                       uint16_t flags, TransmissionState hostState,
                       TransmissionState hmcState, uint32_t plid, bool deconfig,
                       bool guard, uint64_t creationTime) :
-            path(p),
-            sizeOnDisk(size), creator(creator), subsystem(subsystem),
+            path(p), sizeOnDisk(size), creator(creator), subsystem(subsystem),
             severity(sev), actionFlags(flags), hostState(hostState),
             hmcState(hmcState), plid(plid), deconfig(deconfig), guard(guard),
             creationTime(creationTime)

--- a/extensions/openpower-pels/sbe_ffdc_handler.cpp
+++ b/extensions/openpower-pels/sbe_ffdc_handler.cpp
@@ -247,18 +247,6 @@ void SbeFFDC::process(const sbeFfdcPacketType& ffdcPkt)
     // formated FFDC data structure after FFDC packet processing
     FFDC ffdc;
 
-    if (!pdbg_targets_init(NULL))
-    {
-        lg2::error("pdbg_targets_init failed, skipping ffdc processing");
-        return;
-    }
-
-    if (libekb_init())
-    {
-        lg2::error("libekb_init failed, skipping ffdc processing");
-        return;
-    }
-
     try
     {
         // libekb provided wrapper function to convert SBE FFDC

--- a/extensions/openpower-pels/section_header.hpp
+++ b/extensions/openpower-pels/section_header.hpp
@@ -34,8 +34,8 @@ struct SectionHeader
      */
     SectionHeader(uint16_t id, uint16_t size, uint8_t version, uint8_t subType,
                   uint16_t componentID) :
-        id(id),
-        size(size), version(version), subType(subType), componentID(componentID)
+        id(id), size(size), version(version), subType(subType),
+        componentID(componentID)
     {}
 
     /**

--- a/extensions/openpower-pels/service_indicators.cpp
+++ b/extensions/openpower-pels/service_indicators.cpp
@@ -198,8 +198,8 @@ std::vector<std::string> LightPath::getInventoryPaths(
     {
         try
         {
-            auto inventoryPaths = _dataIface.getInventoryFromLocCode(locCode, 0,
-                                                                     true);
+            auto inventoryPaths =
+                _dataIface.getInventoryFromLocCode(locCode, 0, true);
             for (const auto& path : inventoryPaths)
             {
                 if (std::find(paths.begin(), paths.end(), path) == paths.end())

--- a/extensions/openpower-pels/severity.cpp
+++ b/extensions/openpower-pels/severity.cpp
@@ -78,8 +78,8 @@ uint8_t convertOBMCSeverityToPEL(LogSeverity severity)
     return pelSeverity;
 }
 
-std::optional<LogSeverity> fixupLogSeverity(LogSeverity obmcSeverity,
-                                            SeverityType pelSeverity)
+std::optional<LogSeverity>
+    fixupLogSeverity(LogSeverity obmcSeverity, SeverityType pelSeverity)
 {
     bool isNonErrPelSev = (pelSeverity == SeverityType::nonError) ||
                           (pelSeverity == SeverityType::recovered);

--- a/extensions/openpower-pels/severity.hpp
+++ b/extensions/openpower-pels/severity.hpp
@@ -36,8 +36,7 @@ uint8_t convertOBMCSeverityToPEL(phosphor::logging::Entry::Level severity);
  *         found, otherwise std::nullopt which means the original one
  *         is good enough.
  */
-std::optional<phosphor::logging::Entry::Level>
-    fixupLogSeverity(phosphor::logging::Entry::Level obmcSeverity,
-                     SeverityType pelSeverity);
+std::optional<phosphor::logging::Entry::Level> fixupLogSeverity(
+    phosphor::logging::Entry::Level obmcSeverity, SeverityType pelSeverity);
 } // namespace pels
 } // namespace openpower

--- a/extensions/openpower-pels/src.cpp
+++ b/extensions/openpower-pels/src.cpp
@@ -158,8 +158,8 @@ std::optional<std::string> getPythonJSON(std::vector<std::string>& hexwords,
     }
     else
     {
-        std::unique_ptr<PyObject, decltype(&pyDecRef)> modPtr(pModule,
-                                                              &pyDecRef);
+        std::unique_ptr<PyObject, decltype(&pyDecRef)> modPtr(
+            pModule, &pyDecRef);
         std::string funcToCall = "parseSRCToJson";
         PyObject* pKey = PyUnicode_FromString(funcToCall.c_str());
         std::unique_ptr<PyObject, decltype(&pyDecRef)> keyPtr(pKey, &pyDecRef);
@@ -179,8 +179,8 @@ std::optional<std::string> getPythonJSON(std::vector<std::string>& hexwords,
         if (PyCallable_Check(pFunc))
         {
             PyObject* pArgs = PyTuple_New(9);
-            std::unique_ptr<PyObject, decltype(&pyDecRef)> argPtr(pArgs,
-                                                                  &pyDecRef);
+            std::unique_ptr<PyObject, decltype(&pyDecRef)> argPtr(
+                pArgs, &pyDecRef);
             for (size_t i = 0; i < 9; i++)
             {
                 std::string arg{"00000000"};
@@ -196,8 +196,8 @@ std::optional<std::string> getPythonJSON(std::vector<std::string>& hexwords,
             {
                 std::unique_ptr<PyObject, decltype(&pyDecRef)> resPtr(
                     pResult, &pyDecRef);
-                PyObject* pBytes = PyUnicode_AsEncodedString(pResult, "utf-8",
-                                                             "~E~");
+                PyObject* pBytes =
+                    PyUnicode_AsEncodedString(pResult, "utf-8", "~E~");
                 std::unique_ptr<PyObject, decltype(&pyDecRef)> pyBytePtr(
                     pBytes, &pyDecRef);
                 const char* output = PyBytes_AS_STRING(pBytes);
@@ -363,8 +363,8 @@ SRC::SRC(const message::Entry& regEntry, const AdditionalData& additionalData,
     if (ss)
     {
         auto eventSubsystem = std::stoul(*ss, NULL, 16);
-        std::string subsystem = pv::getValue(eventSubsystem,
-                                             pel_values::subsystemValues);
+        std::string subsystem =
+            pv::getValue(eventSubsystem, pel_values::subsystemValues);
         if (subsystem == "invalid")
         {
             lg2::warning("SRC: Invalid SubSystem value: {VAL}", "VAL", lg2::hex,
@@ -400,8 +400,8 @@ void SRC::setUserDefinedHexWords(const message::Entry& regEntry,
         // Can only set words 6 - 9
         if (!isUserDefinedWord(wordNum))
         {
-            std::string msg = "SRC user data word out of range: " +
-                              std::to_string(wordNum);
+            std::string msg =
+                "SRC user data word out of range: " + std::to_string(wordNum);
             addDebugData(msg);
             continue;
         }
@@ -489,9 +489,8 @@ bool SRC::isHostbootSRC() const
     return false;
 }
 
-std::optional<std::string> SRC::getErrorDetails(message::Registry& registry,
-                                                DetailLevel type,
-                                                bool toCache) const
+std::optional<std::string> SRC::getErrorDetails(
+    message::Registry& registry, DetailLevel type, bool toCache) const
 {
     const std::string jsonIndent(indentLevel, 0x20);
     std::string errorOut;
@@ -709,10 +708,10 @@ std::optional<std::string> SRC::getCallouts() const
     return printOut;
 }
 
-std::optional<std::string> SRC::getJSON(message::Registry& registry,
-                                        const std::vector<std::string>& plugins
-                                        [[maybe_unused]],
-                                        uint8_t creatorID) const
+std::optional<std::string>
+    SRC::getJSON(message::Registry& registry,
+                 const std::vector<std::string>& plugins [[maybe_unused]],
+                 uint8_t creatorID) const
 {
     std::string ps;
     std::vector<std::string> hexwords;
@@ -759,8 +758,8 @@ std::optional<std::string> SRC::getJSON(message::Registry& registry,
 
         jsonInsert(
             ps, "Guarded",
-            pv::boolString.at(_hexData[3] &
-                              static_cast<uint32_t>(ErrorStatusFlags::guarded)),
+            pv::boolString.at(
+                _hexData[3] & static_cast<uint32_t>(ErrorStatusFlags::guarded)),
             1);
     }
 
@@ -828,8 +827,8 @@ void SRC::addCallouts(const message::Entry& regEntry,
                       const nlohmann::json& jsonCallouts,
                       const DataInterfaceBase& dataIface)
 {
-    auto registryCallouts = getRegistryCallouts(regEntry, additionalData,
-                                                dataIface);
+    auto registryCallouts =
+        getRegistryCallouts(regEntry, additionalData, dataIface);
 
     auto item = additionalData.getValue("CALLOUT_INVENTORY_PATH");
     auto priority = additionalData.getValue("CALLOUT_PRIORITY");
@@ -897,16 +896,16 @@ void SRC::addInventoryCallout(const std::string& inventoryPath,
         {
             dataIface.getHWCalloutFields(inventoryPath, fn, ccin, sn);
 
-            CalloutPriority p = priority ? priority.value()
-                                         : CalloutPriority::high;
+            CalloutPriority p =
+                priority ? priority.value() : CalloutPriority::high;
 
-            callout = std::make_unique<src::Callout>(p, locCode, fn, ccin, sn,
-                                                     mrus);
+            callout =
+                std::make_unique<src::Callout>(p, locCode, fn, ccin, sn, mrus);
         }
         catch (const sdbusplus::exception_t& e)
         {
-            std::string msg = "No VPD found for " + inventoryPath + ": " +
-                              e.what();
+            std::string msg =
+                "No VPD found for " + inventoryPath + ": " + e.what();
             addDebugData(msg);
 
             // Just create the callout with empty FRU fields
@@ -940,10 +939,9 @@ void SRC::addInventoryCallout(const std::string& inventoryPath,
     }
 }
 
-std::vector<message::RegistryCallout>
-    SRC::getRegistryCallouts(const message::Entry& regEntry,
-                             const AdditionalData& additionalData,
-                             const DataInterfaceBase& dataIface)
+std::vector<message::RegistryCallout> SRC::getRegistryCallouts(
+    const message::Entry& regEntry, const AdditionalData& additionalData,
+    const DataInterfaceBase& dataIface)
 {
     std::vector<message::RegistryCallout> registryCallouts;
 
@@ -996,8 +994,8 @@ void SRC::addRegistryCallouts(
     }
     catch (const std::exception& e)
     {
-        std::string msg = "Error parsing PEL message registry callout JSON: "s +
-                          e.what();
+        std::string msg =
+            "Error parsing PEL message registry callout JSON: "s + e.what();
         addDebugData(msg);
     }
 }
@@ -1027,8 +1025,8 @@ void SRC::addRegistryCallout(
 
     // Via the PEL values table, get the priority enum.
     // The schema will have validated the priority was a valid value.
-    auto priorityIt = pv::findByName(regCallout.priority,
-                                     pv::calloutPriorityValues);
+    auto priorityIt =
+        pv::findByName(regCallout.priority, pv::calloutPriorityValues);
     assert(priorityIt != pv::calloutPriorityValues.end());
     auto priority =
         static_cast<CalloutPriority>(std::get<pv::fieldValuePos>(*priorityIt));
@@ -1145,9 +1143,9 @@ void SRC::addDevicePathCallouts(const AdditionalData& additionalData,
         }
         catch (const std::exception& e)
         {
-            std::string msg = "Invalid CALLOUT_IIC_BUS " + *i2cBus +
-                              " or CALLOUT_IIC_ADDR " + *i2cAddr +
-                              " in AdditionalData property";
+            std::string msg =
+                "Invalid CALLOUT_IIC_BUS " + *i2cBus + " or CALLOUT_IIC_ADDR " +
+                *i2cAddr + " in AdditionalData property";
             addDebugData(msg);
             return;
         }
@@ -1566,8 +1564,8 @@ uint32_t SRC::getProgressCode(std::vector<uint8_t>& rawProgressSRC)
 
         if (std::all_of(progressCodeString.begin(), progressCodeString.end(),
                         [](char c) {
-            return std::isxdigit(static_cast<unsigned char>(c));
-        }))
+                            return std::isxdigit(static_cast<unsigned char>(c));
+                        }))
         {
             progressCode = std::stoul(progressCodeString, nullptr, 16);
         }

--- a/extensions/openpower-pels/src.hpp
+++ b/extensions/openpower-pels/src.hpp
@@ -272,9 +272,9 @@ class SRC : public Section
      * @param[in] toCache - boolean to cache registry in memory, default=false
      * @return std::optional<std::string> - Error details
      */
-    std::optional<std::string> getErrorDetails(message::Registry& registry,
-                                               DetailLevel type,
-                                               bool toCache = false) const;
+    std::optional<std::string>
+        getErrorDetails(message::Registry& registry, DetailLevel type,
+                        bool toCache = false) const;
 
     /**
      * @brief Says if this SRC was created by the BMC (i.e. this code).
@@ -470,12 +470,12 @@ class SRC : public Section
      * @param[in] dataIface - The DataInterface object
      * @param[in] mrus - The MRUs to add to the callout
      */
-    void
-        addInventoryCallout(const std::string& inventoryPath,
-                            const std::optional<CalloutPriority>& priority,
-                            const std::optional<std::string>& locationCode,
-                            const DataInterfaceBase& dataIface,
-                            const std::vector<src::MRU::MRUCallout>& mrus = {});
+    void addInventoryCallout(
+        const std::string& inventoryPath,
+        const std::optional<CalloutPriority>& priority,
+        const std::optional<std::string>& locationCode,
+        const DataInterfaceBase& dataIface,
+        const std::vector<src::MRU::MRUCallout>& mrus = {});
 
     /**
      * @brief Returns the callouts to use from the registry entry.
@@ -484,10 +484,9 @@ class SRC : public Section
      * @param[in] additionalData - The AdditionalData property
      * @param[in] dataIface - The DataInterface object
      */
-    std::vector<message::RegistryCallout>
-        getRegistryCallouts(const message::Entry& regEntry,
-                            const AdditionalData& additionalData,
-                            const DataInterfaceBase& dataIface);
+    std::vector<message::RegistryCallout> getRegistryCallouts(
+        const message::Entry& regEntry, const AdditionalData& additionalData,
+        const DataInterfaceBase& dataIface);
 
     /**
      * @brief Adds the FRU callouts from the list of registry callouts

--- a/extensions/openpower-pels/temporary_file.cpp
+++ b/extensions/openpower-pels/temporary_file.cpp
@@ -18,8 +18,8 @@ namespace util
 TemporaryFile::TemporaryFile(const char* data, const uint32_t len)
 {
     // Build template path required by mkstemp()
-    std::string templatePath = fs::temp_directory_path() /
-                               "phosphor-logging-XXXXXX";
+    std::string templatePath =
+        fs::temp_directory_path() / "phosphor-logging-XXXXXX";
 
     // Generate unique file name, create file, and open it.  The XXXXXX
     // characters are replaced by mkstemp() to make the file name unique.
@@ -37,8 +37,8 @@ TemporaryFile::TemporaryFile(const char* data, const uint32_t len)
         // Delete temporary file.  The destructor won't be called because the
         // exception below causes this constructor to exit without completing.
         remove();
-        throw std::runtime_error{std::string{"Unable to update file: "} +
-                                 strerror(errno)};
+        throw std::runtime_error{
+            std::string{"Unable to update file: "} + strerror(errno)};
     }
 
     // Store path to temporary file

--- a/extensions/openpower-pels/tools/peltool.cpp
+++ b/extensions/openpower-pels/tools/peltool.cpp
@@ -301,11 +301,10 @@ std::vector<std::string> getPlugins()
  * @return std::string - JSON string of PEL entry (empty if fullPEL is true)
  */
 template <typename T>
-std::string genPELJSON(T itr, bool hidden, bool includeInfo, bool critSysTerm,
-                       bool fullPEL, bool& foundPEL,
-                       const std::optional<std::regex>& scrubRegex,
-                       const std::vector<std::string>& plugins, bool hexDump,
-                       bool archive)
+std::string genPELJSON(
+    T itr, bool hidden, bool includeInfo, bool critSysTerm, bool fullPEL,
+    bool& foundPEL, const std::optional<std::regex>& scrubRegex,
+    const std::vector<std::string>& plugins, bool hexDump, bool archive)
 {
     std::string val;
     std::string listStr;
@@ -497,8 +496,8 @@ void printPELs(bool order, bool hidden, bool includeInfo, bool critSysTerm,
     // Sort the pairs based on second time parameter
     std::sort(PELs.begin(), PELs.end(),
               [](const auto& left, const auto& right) {
-        return left.second < right.second;
-    });
+                  return left.second < right.second;
+              });
 
     bool foundPEL = false;
 

--- a/extensions/openpower-pels/user_data.cpp
+++ b/extensions/openpower-pels/user_data.cpp
@@ -94,10 +94,9 @@ void UserData::validate()
     }
 }
 
-std::optional<std::string>
-    UserData::getJSON(uint8_t creatorID [[maybe_unused]],
-                      const std::vector<std::string>& plugins
-                      [[maybe_unused]]) const
+std::optional<std::string> UserData::getJSON(
+    uint8_t creatorID [[maybe_unused]],
+    const std::vector<std::string>& plugins [[maybe_unused]]) const
 {
 #ifdef PELTOOL
     return user_data::getJSON(_header.componentID, _header.subType,

--- a/extensions/openpower-pels/user_data_json.cpp
+++ b/extensions/openpower-pels/user_data_json.cpp
@@ -253,10 +253,9 @@ std::optional<std::string>
  * @return std::optional<std::string> - The JSON string if it could be created,
  *                                      else std::nullopt
  */
-std::optional<std::string> getPythonJSON(uint16_t componentID, uint8_t subType,
-                                         uint8_t version,
-                                         const std::vector<uint8_t>& data,
-                                         uint8_t creatorID)
+std::optional<std::string>
+    getPythonJSON(uint16_t componentID, uint8_t subType, uint8_t version,
+                  const std::vector<uint8_t>& data, uint8_t creatorID)
 {
     PyObject *pName, *pModule, *eType, *eValue, *eTraceback, *pKey;
     std::string pErrStr;
@@ -291,8 +290,8 @@ std::optional<std::string> getPythonJSON(uint16_t componentID, uint8_t subType,
     }
     else
     {
-        std::unique_ptr<PyObject, decltype(&pyDecRef)> modPtr(pModule,
-                                                              &pyDecRef);
+        std::unique_ptr<PyObject, decltype(&pyDecRef)> modPtr(
+            pModule, &pyDecRef);
         std::string funcToCall = "parseUDToJson";
         pKey = PyUnicode_FromString(funcToCall.c_str());
         std::unique_ptr<PyObject, decltype(&pyDecRef)> keyPtr(pKey, &pyDecRef);
@@ -315,8 +314,8 @@ std::optional<std::string> getPythonJSON(uint16_t componentID, uint8_t subType,
         {
             auto ud = data.data();
             PyObject* pArgs = PyTuple_New(3);
-            std::unique_ptr<PyObject, decltype(&pyDecRef)> argPtr(pArgs,
-                                                                  &pyDecRef);
+            std::unique_ptr<PyObject, decltype(&pyDecRef)> argPtr(
+                pArgs, &pyDecRef);
             PyTuple_SetItem(pArgs, 0,
                             PyLong_FromUnsignedLong((unsigned long)subType));
             PyTuple_SetItem(pArgs, 1,
@@ -331,8 +330,8 @@ std::optional<std::string> getPythonJSON(uint16_t componentID, uint8_t subType,
             {
                 std::unique_ptr<PyObject, decltype(&pyDecRef)> resPtr(
                     pResult, &pyDecRef);
-                PyObject* pBytes = PyUnicode_AsEncodedString(pResult, "utf-8",
-                                                             "~E~");
+                PyObject* pBytes =
+                    PyUnicode_AsEncodedString(pResult, "utf-8", "~E~");
                 std::unique_ptr<PyObject, decltype(&pyDecRef)> pyBytePtr(
                     pBytes, &pyDecRef);
                 const char* output = PyBytes_AS_STRING(pBytes);
@@ -393,11 +392,10 @@ std::optional<std::string> getPythonJSON(uint16_t componentID, uint8_t subType,
     return std::nullopt;
 }
 
-std::optional<std::string> getJSON(uint16_t componentID, uint8_t subType,
-                                   uint8_t version,
-                                   const std::vector<uint8_t>& data,
-                                   uint8_t creatorID,
-                                   const std::vector<std::string>& plugins)
+std::optional<std::string>
+    getJSON(uint16_t componentID, uint8_t subType, uint8_t version,
+            const std::vector<uint8_t>& data, uint8_t creatorID,
+            const std::vector<std::string>& plugins)
 {
     std::string subsystem = getNumberString("%c", tolower(creatorID));
     std::string component = getNumberString("%04x", componentID);

--- a/extensions/openpower-pels/user_data_json.hpp
+++ b/extensions/openpower-pels/user_data_json.hpp
@@ -20,10 +20,9 @@ namespace openpower::pels::user_data
  * @return std::optional<std::string> - The JSON string if it could be created,
  *                                      else std::nullopt.
  */
-std::optional<std::string> getJSON(uint16_t componentID, uint8_t subType,
-                                   uint8_t version,
-                                   const std::vector<uint8_t>& data,
-                                   uint8_t creatorID,
-                                   const std::vector<std::string>& plugins);
+std::optional<std::string>
+    getJSON(uint16_t componentID, uint8_t subType, uint8_t version,
+            const std::vector<uint8_t>& data, uint8_t creatorID,
+            const std::vector<std::string>& plugins);
 
 } // namespace openpower::pels::user_data

--- a/extensions/openpower-pels/user_header.cpp
+++ b/extensions/openpower-pels/user_header.cpp
@@ -64,8 +64,8 @@ UserHeader::UserHeader(const message::Entry& entry,
     if (ss)
     {
         auto eventSubsystem = std::stoul(*ss, NULL, 16);
-        std::string subsystemString = pv::getValue(eventSubsystem,
-                                                   pel_values::subsystemValues);
+        std::string subsystemString =
+            pv::getValue(eventSubsystem, pel_values::subsystemValues);
         if (subsystemString == "invalid")
         {
             lg2::warning(
@@ -260,8 +260,8 @@ std::optional<std::string> UserHeader::getJSON(uint8_t creatorID) const
     subsystem = pv::getValue(_eventSubsystem, pel_values::subsystemValues);
     eventScope = pv::getValue(_eventScope, pel_values::eventScopeValues);
     eventType = pv::getValue(_eventType, pel_values::eventTypeValues);
-    actionFlags = pv::getValuesBitwise(_actionFlags,
-                                       pel_values::actionFlagsValues);
+    actionFlags =
+        pv::getValuesBitwise(_actionFlags, pel_values::actionFlagsValues);
 
     std::string hostState{"Invalid"};
     std::string hmcState{"Invalid"};

--- a/lib/include/phosphor-logging/lg2/conversion.hpp
+++ b/lib/include/phosphor-logging/lg2/conversion.hpp
@@ -29,8 +29,8 @@ namespace lg2::details
 template <typename T>
 concept string_like_type =
     (std::constructible_from<std::string_view, T> ||
-     std::same_as<std::filesystem::path,
-                  std::decay_t<T>>)&&!std::same_as<std::nullptr_t, T>;
+     std::same_as<std::filesystem::path, std::decay_t<T>>) &&
+    !std::same_as<std::nullptr_t, T>;
 
 /** Concept to determine if an item acts like a pointer.
  *
@@ -38,8 +38,9 @@ concept string_like_type =
  *  pointer.
  */
 template <typename T>
-concept pointer_type = (std::is_pointer_v<T> ||
-                        std::same_as<std::nullptr_t, T>)&&!string_like_type<T>;
+concept pointer_type =
+    (std::is_pointer_v<T> || std::same_as<std::nullptr_t, T>) &&
+    !string_like_type<T>;
 
 /** Concept to determine if an item acts like an unsigned_integral.
  *
@@ -47,8 +48,8 @@ concept pointer_type = (std::is_pointer_v<T> ||
  *  `True` and `False` strings.
  */
 template <typename T>
-concept unsigned_integral_except_bool = !std::same_as<T, bool> &&
-                                        std::unsigned_integral<T>;
+concept unsigned_integral_except_bool =
+    !std::same_as<T, bool> && std::unsigned_integral<T>;
 
 template <typename T>
 concept sdbusplus_enum = sdbusplus::message::has_convert_from_string_v<T>;
@@ -64,8 +65,8 @@ template <typename T>
 concept has_to_string = requires(T&& t) { to_string(t); };
 
 template <typename T>
-concept is_raw_enum = std::is_enum_v<std::decay_t<T>> && !sdbusplus_enum<T> &&
-                      !has_to_string<T>;
+concept is_raw_enum =
+    std::is_enum_v<std::decay_t<T>> && !sdbusplus_enum<T> && !has_to_string<T>;
 
 /** Concept listing all of the types we know how to convert into a format
  *  for logging.
@@ -238,8 +239,8 @@ static auto log_convert(const char* h, log_flag<Fs...> f, V v)
 
     // Cast (void*) to a hex-formatted uint64 using the target's pointer-size
     // to determine field-width.
-    constexpr static auto new_f = sizeof(void*) == 4 ? field32.value
-                                                     : field64.value;
+    constexpr static auto new_f =
+        sizeof(void*) == 4 ? field32.value : field64.value;
 
     return std::make_tuple(h, new_f | (hex | unsigned_val).value,
                            reinterpret_cast<uint64_t>(v));

--- a/lib/lg2_logger.cpp
+++ b/lib/lg2_logger.cpp
@@ -209,10 +209,10 @@ static void cerr_extra_output(level l, const std::source_location& s,
 
 // Use the cerr output method if we are on a TTY or if explicitly set via
 // environment variable.
-static auto extra_output_method = (isatty(fileno(stderr)) ||
-                                   nullptr != getenv("LG2_FORCE_STDERR"))
-                                      ? cerr_extra_output
-                                      : noop_extra_output;
+static auto extra_output_method =
+    (isatty(fileno(stderr)) || nullptr != getenv("LG2_FORCE_STDERR"))
+        ? cerr_extra_output
+        : noop_extra_output;
 
 // Do_log implementation.
 void do_log(level l, const std::source_location& s, const char* m, ...)

--- a/log_manager.cpp
+++ b/log_manager.cpp
@@ -384,8 +384,8 @@ void Manager::quiesceOnError(const uint32_t entryId)
     // Verify we don't already have this entry blocking
     auto it = find_if(this->blockingErrors.begin(), this->blockingErrors.end(),
                       [&](const std::unique_ptr<Block>& obj) {
-        return obj->entryId == entryId;
-    });
+                          return obj->entryId == entryId;
+                      });
     if (it != this->blockingErrors.end())
     {
         // Already recorded so just return
@@ -396,8 +396,8 @@ void Manager::quiesceOnError(const uint32_t entryId)
 
     lg2::info("QuiesceOnError set and callout present");
 
-    auto blockPath = std::string(OBJ_LOGGING) + "/block" +
-                     std::to_string(entryId);
+    auto blockPath =
+        std::string(OBJ_LOGGING) + "/block" + std::to_string(entryId);
     auto blockObj = std::make_unique<Block>(this->busLog, blockPath, entryId);
     this->blockingErrors.push_back(std::move(blockObj));
 
@@ -470,8 +470,8 @@ void Manager::checkAndRemoveBlockingError(uint32_t entryId)
     // First look for blocking object and remove
     auto it = find_if(blockingErrors.begin(), blockingErrors.end(),
                       [&](const std::unique_ptr<Block>& obj) {
-        return obj->entryId == entryId;
-    });
+                          return obj->entryId == entryId;
+                      });
     if (it != blockingErrors.end())
     {
         blockingErrors.erase(it);

--- a/log_manager.hpp
+++ b/log_manager.hpp
@@ -73,7 +73,7 @@ class Manager : public details::ServerObject<details::ManagerIface>
      */
     Manager(sdbusplus::bus_t& bus, const char* objPath) :
         details::ServerObject<details::ManagerIface>(bus, objPath), busLog(bus),
-        entryId(0), fwVersion(readFWVersion()){};
+        entryId(0), fwVersion(readFWVersion()) {};
 
     /*
      * @fn commit()
@@ -354,7 +354,7 @@ class Manager : public details::ServerObject<DeleteAllIface, CreateIface>
             bus, path.c_str(),
             details::ServerObject<DeleteAllIface,
                                   CreateIface>::action::defer_emit),
-        manager(manager){};
+        manager(manager) {};
 
     /** @brief Delete all d-bus objects.
      */

--- a/logging_test.cpp
+++ b/logging_test.cpp
@@ -126,8 +126,8 @@ int elog_test()
     if (rc)
         return (rc);
 
-    rc = validate_journal(TestErrorOne::FILE_NAME::str_short,
-                          "elog_test_3.txt");
+    rc =
+        validate_journal(TestErrorOne::FILE_NAME::str_short, "elog_test_3.txt");
     if (rc)
         return (rc);
 
@@ -171,8 +171,8 @@ int elog_test()
     if (rc)
         return (rc);
 
-    rc = validate_journal(TestErrorOne::FILE_NAME::str_short,
-                          "elog_test_4.txt");
+    rc =
+        validate_journal(TestErrorOne::FILE_NAME::str_short, "elog_test_4.txt");
     if (rc)
         return (rc);
 

--- a/meson.build
+++ b/meson.build
@@ -115,7 +115,9 @@ log_manager_ext_args = []
 
 subdir('extensions')
 subdir('phosphor-rsyslog-config')
-subdir('phosphor-auditlog')
+if(get_option('auditlog').enabled())
+    subdir('phosphor-auditlog')
+endif
 
 # Generate daemon.
 log_manager_sources = [

--- a/meson.build
+++ b/meson.build
@@ -115,6 +115,7 @@ log_manager_ext_args = []
 
 subdir('extensions')
 subdir('phosphor-rsyslog-config')
+subdir('phosphor-auditlog')
 
 # Generate daemon.
 log_manager_sources = [

--- a/meson.options
+++ b/meson.options
@@ -9,6 +9,13 @@ option(
 
 option('yamldir', type: 'string', description: 'Path to YAML')
 option(
+    'auditlog',
+    type: 'feature',
+    value: 'disabled',
+    description: 'Enable D-Bus Audit Log servce',
+)
+
+option(
     'callout_yaml',
     type: 'string',
     value: 'callouts/callouts-example.yaml',

--- a/phosphor-auditlog/alog_manager.cpp
+++ b/phosphor-auditlog/alog_manager.cpp
@@ -1,0 +1,110 @@
+#include "alog_manager.hpp"
+
+#include "alog_parser.hpp"
+#include "alog_utils.hpp"
+
+#include <fcntl.h>
+#include <libaudit.h>
+
+#include <phosphor-logging/lg2.hpp>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/source/event.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+
+#include <cstring>
+#include <string>
+
+namespace phosphor::auditlog
+{
+
+sdbusplus::message::unix_fd ALManager::getAuditLog()
+{
+#ifdef AUDITLOG_KEEP_JSONFILE
+    ALParseFile parsedFile("/tmp/auditLog.json");
+#else
+    ALParseFile parsedFile;
+#endif
+
+    // Initialize to parse full audit log
+    ALParseAll auditParser(parsedFile);
+
+    lg2::debug("Method GetAuditLog: {FILEPATH}", "FILEPATH",
+               parsedFile.getPath());
+
+    // Parse all the events
+    auditParser.doParse();
+
+    /* Get file descriptor to return.
+     * openParseFD() throws an error if it fails to open the file.
+     */
+    auto fd = openParseFD(parsedFile);
+
+    /* Schedule the fd to be closed by sdbusplus when it sends it back over
+     * D-Bus.
+     */
+    sdeventplus::Event event = sdeventplus::Event::get_default();
+    fdCloseEventSource = std::make_unique<sdeventplus::source::Defer>(
+        event, std::bind(&ALManager::closeFD, this, fd, std::placeholders::_1));
+
+    return fd;
+}
+
+sdbusplus::message::unix_fd ALManager::getLatestEntries(uint32_t maxEvents)
+{
+#ifdef AUDITLOG_KEEP_JSONFILE
+    ALParseFile parsedFile("/tmp/auditEntries.json");
+#else
+    ALParseFile parsedFile;
+#endif
+
+    lg2::debug("Method GetLatestEntries: {FILE} maxEvents: {MAXCOUNT}", "FILE",
+               parsedFile.getPath(), "MAXCOUNT", maxEvents);
+
+    ALParseLatest auditParser(maxEvents, parsedFile);
+
+    // Parse events up to maxEvents specified
+    auditParser.doParse();
+
+    /* Get file descriptor to return.
+     * openParseFD() throws an error if it fails to open the file.
+     */
+    auto fd = openParseFD(parsedFile);
+
+    /* Schedule the fd to be closed by sdbusplus when it sends it back over
+     * D-Bus.
+     */
+    sdeventplus::Event event = sdeventplus::Event::get_default();
+    fdCloseEventSource = std::make_unique<sdeventplus::source::Defer>(
+        event, std::bind(&ALManager::closeFD, this, fd, std::placeholders::_1));
+
+    return fd;
+}
+
+int ALManager::openParseFD(const ALParseFile& parsedFile)
+{
+    // Confirm parsed file exists
+    int fd = -1;
+    std::error_code ec;
+
+    fd = open(parsedFile.getPath().c_str(), O_RDONLY | O_NONBLOCK);
+    if (fd == -1)
+    {
+        auto e = errno;
+        lg2::error("Failed to open {PATH}: {ERRNO}", "ERRNO", e, "PATH",
+                   parsedFile.getPath());
+        throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+    }
+
+    lg2::debug("Opening parsedFile: {PARSEFD}", "PARSEFD", fd);
+
+    return fd;
+}
+
+void ALManager::closeFD(int fd, sdeventplus::source::EventBase& /*source*/)
+{
+    lg2::debug("Closing parsedFile: {FD}", "FD", fd);
+    close(fd);
+    fdCloseEventSource.reset();
+}
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/alog_manager.hpp
+++ b/phosphor-auditlog/alog_manager.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "alog_utils.hpp"
+
+#include <libaudit.h>
+
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <sdeventplus/event.hpp>
+#include <sdeventplus/source/event.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+#include <xyz/openbmc_project/Logging/AuditLog/server.hpp>
+
+#include <string>
+
+namespace phosphor::auditlog
+{
+
+using ALIface = sdbusplus::xyz::openbmc_project::Logging::server::AuditLog;
+using ALObject = sdbusplus::server::object_t<ALIface>;
+
+/** @class ALManager
+ *  @brief Configuration for AuditLog server
+ *  @details A concrete implementation of the
+ *  xyz.openbmc_project.Logging.AuditLog API, in order to
+ *  provide audit log support.
+ */
+class ALManager : public ALObject
+{
+  public:
+    ALManager() = delete;
+    ALManager(const ALManager&) = delete;
+    ALManager& operator=(const ALManager&) = delete;
+    ALManager(ALManager&&) = delete;
+    ALManager& operator=(ALManager&&) = delete;
+    ~ALManager() = default;
+
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] path - Path to attach at.
+     */
+    ALManager(sdbusplus::bus_t& bus, const std::string& path) :
+        ALObject(bus, path.c_str()){};
+
+    /**
+     * @brief Parses all audit log events into JSON format.
+     * @details Entries are sorted oldest to newest.
+     * @return unix_fd A read-only file descriptor to the parsed file.
+     */
+    sdbusplus::message::unix_fd getAuditLog() override;
+
+    /**
+     * @brief Parses subset of audit log events into JSON format.
+     * @details Entries are sorted newest to oldest.
+     * @param[in] maxCount - The maximum number of entries to return. Minimum
+     *            value of 1.
+     * @return unix_fd A read-only file descriptor to the parsed file.
+     */
+    sdbusplus::message::unix_fd getLatestEntries(uint32_t maxCount) override;
+
+  private:
+    /**
+     * @brief Opens previously created file in read-only mode.
+     * @param[in] parsedFile - Path to file to open
+     * @return int A file descriptor to the opened file.
+     */
+    int openParseFD(const ALParseFile& parsedFile);
+
+    /**
+     * @brief The event source for closing the file descriptor after it
+     *        has been returned from the getAuditLog or getLatestEntries
+     *        D-Bus method.
+     * @details This is shared for multiple methods. The Defer action is called
+     * before the event loop processes another event so there should not be any
+     * collisions between the multiple uses.
+     */
+    std::unique_ptr<sdeventplus::source::Defer> fdCloseEventSource;
+
+    /**
+     * @brief Closes the file descriptor passed in.
+     * @details This is called from the event loop to close FDs returned from
+     * getAuditLog() or getLatestEntries()
+     * @param[in] fd - The file descriptor to close
+     * @param[in] source - The event source object used
+     */
+    void closeFD(int fd, sdeventplus::source::EventBase& source);
+};
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/alog_parser.cpp
+++ b/phosphor-auditlog/alog_parser.cpp
@@ -1,0 +1,425 @@
+#include "alog_parser.hpp"
+
+#include "alog_manager.hpp"
+
+#include <auparse.h>
+#include <libaudit.h>
+
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+
+#include <cstring>
+#include <filesystem>
+#include <format>
+#include <list>
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace phosphor::auditlog
+{
+
+bool ALParser::getNextEvent()
+{
+    bool haveEvent = false;
+    int rc;
+
+    rc = auparse_next_event(au);
+    switch (rc)
+    {
+        case 1:
+            /* Success, pointing to next event */
+            haveEvent = true;
+            break;
+        case 0:
+            /* No more events */
+            haveEvent = false;
+            break;
+        case -1:
+        default:
+            /* Failure */
+            lg2::error("Failed to parse next event");
+            haveEvent = false;
+            break;
+    }
+
+    return haveEvent;
+}
+
+void ALParser::parseEvent()
+{
+    unsigned int nRecords = auparse_get_num_records(au);
+
+    // The event itself is a record. It may be the only one.
+    parseRecord();
+
+    /* Handle any additional records for this event */
+    for (unsigned int iter = 1; iter < nRecords; iter++)
+    {
+        auto rc = auparse_next_record(au);
+
+        switch (rc)
+        {
+            case 1:
+            {
+                /* Success finding record, parse it! */
+                parseRecord();
+            }
+            break;
+            case 0:
+                /* No more records, something is confused! */
+                lg2::error(
+                    "Record count ({NRECS}) and records out of sync ({ITER})",
+                    "NRECS", nRecords, "ITER", iter);
+                throw sdbusplus::xyz::openbmc_project::Common::Error::
+                    InternalFailure();
+
+                break;
+            case -1:
+            default:
+                /* Error */
+                lg2::error("Failed on record: {ITER}", "ITER", iter);
+                throw sdbusplus::xyz::openbmc_project::Common::Error::
+                    InternalFailure();
+                break;
+        }
+    }
+}
+
+void ALParser::fillAuditEntry(nlohmann::json& parsedEntry)
+{
+    parsedEntry["MessageId"] = "OpenBMC.0.5.AuditLogEntry";
+
+    /* MessageArgs: msg */
+    auto recMsg = auparse_get_record_text(au);
+    auto messageArgs = nlohmann::json::array({recMsg});
+
+    parsedEntry["MessageArgs"] = std::move(messageArgs);
+}
+
+/**
+ * @brief Strips '"' from beginning and end of value field
+ */
+inline std::string_view getValue(std::string_view fieldText)
+{
+    if (fieldText.starts_with('\"'))
+    {
+        auto endQuote = fieldText.find('\"', 1);
+
+        if (endQuote != std::string::npos)
+        {
+            return fieldText.substr(1, endQuote - 1);
+        }
+    }
+
+    return fieldText;
+}
+
+void ALParser::fillUsysEntry(nlohmann::json& parsedEntry)
+{
+    parsedEntry["MessageId"] = "OpenBMC.0.5.AuditLogUsysConfig";
+
+    nlohmann::json messageArgs = nlohmann::json::array();
+
+    /* Map expected fields to MessageArgs index.
+     * Audit records contain fields not returned for admin use. E.g. the pid of
+     * the auditd daemon that recorded the entry is part of the record.
+     */
+    std::map<std::string, int>::const_iterator mapEntry;
+    const std::map<std::string, int> msgArgMap({{"type", 0},
+                                                {"op", 1},
+                                                {"acct", 2},
+                                                {"exe", 3},
+                                                {"hostname", 4},
+                                                {"addr", 5},
+                                                {"terminal", 6},
+                                                {"res", 7}});
+
+    /* Walk the fields and insert mapped fields into messageArgs */
+    int fieldIdx = 0;
+    size_t nFields = 0; // Used to confirm all expected fields found
+    do
+    {
+        fieldIdx++;
+
+        // Can return nullptr
+        const char* fieldName = auparse_get_field_name(au);
+        std::string_view fieldTxt = auparse_get_field_str(au);
+
+        if ((fieldName == nullptr) || (fieldTxt.empty()))
+        {
+            lg2::debug("Unexpected field:{FIELDIDX}", "FIELDIDX", fieldIdx);
+            continue;
+        }
+
+        /* Map the field to the message arg, not all fields are args */
+        mapEntry = msgArgMap.find(fieldName);
+        if (mapEntry != msgArgMap.end())
+        {
+            /* Remove '"' from fieldTxt */
+            messageArgs[mapEntry->second] = getValue(fieldTxt);
+            nFields++;
+#ifdef AUDITLOG_FULL_DEBUG
+            lg2::debug(
+                "Field {NFIELD} : {FIELDNAME} = {FIELDSTR} argIdx = {ARGIDX}",
+                "NFIELD", fieldIdx, "FIELDNAME", fieldName, "FIELDSTR",
+                fieldTxt.c_str(), "ARGIDX", mapEntry->second);
+#endif // AUDITLOG_FULL_DEBUG
+        }
+    } while (auparse_next_field(au) == 1);
+
+    /* Error handling, make sure all the fields we care about
+     * exist. If any are missing set to null string.
+     */
+    if (nFields != msgArgMap.size())
+    {
+#ifdef AUDITLOG_FULL_DEBUG
+        lg2::debug("Incorrect nFields = {NFIELDS}", "NFIELDS", nFields);
+#endif // AUDITLOG_FULL_DEBUG
+
+        // Set missing fields to empty string
+        size_t argIdx;
+        for (argIdx = 0;
+             (nFields != msgArgMap.size()) && (argIdx < msgArgMap.size());
+             argIdx++)
+        {
+            if (messageArgs[argIdx] == nullptr)
+            {
+#ifdef AUDITLOG_FULL_DEBUG
+                lg2::debug("Correcting arg={ARGIDX}", "ARGIDX", argIdx);
+#endif // AUDITLOG_FULL_DEBUG
+                messageArgs[argIdx] = "";
+                nFields++;
+            }
+        }
+
+#ifdef AUDITLOG_FULL_DEBUG
+        lg2::debug("nFields = {NFIELDS}", "NFIELDS", nFields);
+#endif // AUDITLOG_FULL_DEBUG
+    }
+
+    parsedEntry["MessageArgs"] = std::move(messageArgs);
+}
+
+bool ALParser::formatMsgReg(nlohmann::json& parsedEntry)
+{
+    /* Fill common fields for any record type */
+    auto fullTimestamp = auparse_get_timestamp(au);
+    if (fullTimestamp == nullptr)
+    {
+        lg2::error("Failed to parse timestamp");
+        throw sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure();
+    }
+    parsedEntry["EventTimestamp"] = fullTimestamp->sec;
+    parsedEntry["ID"] = std::format("{}.{}:{}", fullTimestamp->sec,
+                                    fullTimestamp->milli,
+                                    fullTimestamp->serial);
+
+    /* Fill varied args fields based on record type */
+    int recType = auparse_get_type(au);
+
+    switch (recType)
+    {
+        case AUDIT_USYS_CONFIG:
+            fillUsysEntry(parsedEntry);
+            break;
+
+        default:
+            fillAuditEntry(parsedEntry);
+            break;
+    }
+
+#ifdef AUDITLOG_FULL_DEBUG
+    lg2::debug("parsedEntry = {PARSEDENTRY}", "PARSEDENTRY",
+               parsedEntry.dump());
+#endif // AUDITLOG_FULL_DEBUG
+
+    return true;
+}
+
+bool ALParser::formatGeneral(nlohmann::json& parsedEntry)
+{
+    auto fullTimestamp = auparse_get_timestamp(au);
+    if (fullTimestamp == nullptr)
+    {
+        lg2::error("Failed to parse timestamp");
+        throw sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure();
+    }
+    parsedEntry["EventTimestamp"] = fullTimestamp->sec;
+    parsedEntry["ID"] = std::format("{}.{}:{}", fullTimestamp->sec,
+                                    fullTimestamp->milli,
+                                    fullTimestamp->serial);
+
+    auto recMsg = auparse_get_record_text(au);
+    parsedEntry["Event"] = recMsg;
+
+#ifdef AUDITLOG_FULL_DEBUG
+    lg2::debug("parsedEntry = {PARSEDENTRY}", "PARSEDENTRY",
+               parsedEntry.dump());
+#endif // AUDITLOG_FULL_DEBUG
+
+    return true;
+}
+
+bool ALParser::formatRaw(nlohmann::json& parsedEntry)
+{
+    auto recMsg = auparse_get_record_text(au);
+    parsedEntry["Event"] = recMsg;
+
+#ifdef AUDITLOG_FULL_DEBUG
+    lg2::debug("parsedEntry = {PARSEDENTRY}", "PARSEDENTRY",
+               parsedEntry.dump());
+#endif // AUDITLOG_FULL_DEBUG
+
+    return true;
+}
+
+void ALParser::parseRecord()
+{
+    nlohmann::json parsedEntry;
+
+    if (formatEntry(parsedEntry))
+    {
+        // Dump JSON object to parsedStream
+        parsedStream << parsedEntry.dump() << '\n';
+    }
+
+    return;
+}
+
+bool ALParser::openParsedFile(const std::string& filePath)
+{
+    std::error_code ec;
+
+    /* Expect the file has already been created */
+    if (!std::filesystem::exists(filePath, ec))
+    {
+        lg2::error("File {FILE} doesn't already exist.", "FILE", filePath);
+        return false;
+    }
+
+    // Create/Open file using truncate
+    parsedStream.open(filePath, std::ios::out);
+    if (parsedStream.fail())
+    {
+        lg2::error("Failed to open {FILE}", "FILE", filePath);
+        throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+    }
+
+    return true;
+}
+
+void ALParser::processEvents()
+{
+    // Loop over all the events
+    while (getNextEvent())
+    {
+        parseEvent();
+    }
+}
+
+void ALParser::doParse()
+{
+    lg2::debug("Parsing All");
+    processEvents();
+}
+
+void ALParseLatest::parseRecord()
+{
+    nlohmann::json parsedEntry;
+
+    if (formatEntry(parsedEntry))
+    {
+        // Keep list limited to maxLeftCount
+        if (parsedEntries.size() >= maxLeftCount)
+        {
+            parsedEntries.pop_back();
+        }
+
+        parsedEntries.emplace_front(parsedEntry.dump());
+    }
+
+    return;
+}
+
+size_t ALParseLatest::writeParsedEntries()
+{
+    /* Add newest events to the file */
+    for (const auto& iter : parsedEntries)
+    {
+        parsedStream << iter << '\n';
+    }
+
+    auto parsedCount = parsedEntries.size();
+    parsedEntries.clear();
+
+    lg2::debug("maxLeftCount: {MAXCOUNT} parsedCount: {PARSED}", "MAXCOUNT",
+               maxLeftCount, "PARSED", parsedCount);
+
+    return parsedCount;
+}
+
+void ALParseLatest::doParse()
+{
+    lg2::debug("Parsing maxCount: {MAXCOUNT}", "MAXCOUNT", maxCount);
+    if (maxCount > 0)
+    {
+        processEvents();
+
+        auto parsedCount = writeParsedEntries();
+
+        // Process next file if needed to reach desired # entries
+        while (parsedCount < maxLeftCount)
+        {
+            maxLeftCount -= parsedCount;
+
+            if (!initNextLog())
+            {
+                // No more files to parse
+                break;
+            }
+
+            processEvents();
+
+            /* Add newest events to the file */
+            parsedCount = writeParsedEntries();
+        }
+    }
+}
+
+bool ALParseLatest::initNextLog()
+{
+    if (au != nullptr)
+    {
+        lg2::debug("initNextLog: destroying existing au");
+        auparse_destroy(au);
+        au = nullptr;
+    }
+
+    /* Determine path of next log file to process.
+     * Newest file has no extension and matches 0 index value.
+     */
+    std::string logFilePath = "/var/log/audit/audit.log";
+
+    if (logFileIdx)
+    {
+        logFilePath = std::format("/var/log/audit/audit.log.{}",
+                                  std::to_string(logFileIdx));
+    }
+
+    lg2::debug("initNextLog: Initialize for {FILE}", "FILE", logFilePath);
+    au = auparse_init(AUSOURCE_FILE, logFilePath.c_str());
+
+    if (au != nullptr)
+    {
+        logFileIdx++;
+        return true;
+    }
+
+    // No more files to process
+    return false;
+}
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/alog_parser.cpp
+++ b/phosphor-auditlog/alog_parser.cpp
@@ -227,7 +227,8 @@ bool ALParser::formatMsgReg(nlohmann::json& parsedEntry)
             break;
 
         default:
-            fillAuditEntry(parsedEntry);
+            /* Skip these entries */
+            return false;
             break;
     }
 

--- a/phosphor-auditlog/alog_parser.hpp
+++ b/phosphor-auditlog/alog_parser.hpp
@@ -123,8 +123,9 @@ class ALParser
     /**
      * @brief Parses AUDIT_USYS_CONFIG audit entry into JSON format
      * @details Expected fields from audit log entry are split into MessageArgs
+     * @return bool True entry was filled in, false otherwise.
      */
-    void fillUsysEntry(nlohmann::json& parsedEntry);
+    bool fillUsysEntry(nlohmann::json& parsedEntry);
 
     /**
      * @brief Opens and truncates specified file

--- a/phosphor-auditlog/alog_parser.hpp
+++ b/phosphor-auditlog/alog_parser.hpp
@@ -1,0 +1,256 @@
+#pragma once
+
+#include "alog_utils.hpp"
+
+#include <auparse.h>
+#include <libaudit.h>
+
+#include <nlohmann/json.hpp>
+#include <phosphor-logging/lg2.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+#include <xyz/openbmc_project/Common/error.hpp>
+#include <xyz/openbmc_project/Logging/AuditLog/server.hpp>
+
+#include <fstream>
+#include <list>
+#include <string>
+
+namespace phosphor::auditlog
+{
+
+/** @class ALParser
+ *  @brief Parsing audit log using auparse library services
+ *  @details Provides abstraction to auparse library services
+ */
+class ALParser
+{
+  public:
+    ALParser(const ALParser&) = delete;
+    ALParser& operator=(const ALParser&) = delete;
+    ALParser(ALParser&&) = delete;
+    ALParser& operator=(ALParser&&) = delete;
+
+    /** @brief Constructor to initialize parsing of audit log files
+     *  @details Prepares parsedFile for writing of audit events
+     *  @param[in] parsedFile Initialized file for holding parsed log events
+     */
+    explicit ALParser(ALParseFile& parsedFile)
+    {
+        if (!openParsedFile(parsedFile.getPath()))
+        {
+            throw sdbusplus::xyz::openbmc_project::Common::File::Error::Write();
+        }
+    }
+
+    ~ALParser()
+    {
+        auparse_destroy(au);
+    }
+
+    /**
+     * @brief Process audit events from initialized au source
+     */
+    virtual void doParse();
+
+    /**
+     * @brief Process audit events from initialized au source
+     */
+    void processEvents();
+
+  protected:
+    /**
+     * @brief Format audit entries into raw JSON
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    virtual bool formatEntry(nlohmann::json& parsedEntry)
+    {
+        return formatRaw(parsedEntry);
+    };
+
+    /**
+     * @brief Formats next record into JSON format using message registry
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatMsgReg(nlohmann::json& parsedEntry);
+
+    /**
+     * @brief Formats next record into JSON general format
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatGeneral(nlohmann::json& parsedEntry);
+
+    /**
+     * @brief Formats next record into JSON raw format
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatRaw(nlohmann::json& parsedEntry);
+
+    auparse_state_t* au = nullptr;
+    std::ofstream parsedStream;
+
+  private:
+    /**
+     * @brief Moves parser to point to next event
+     *
+     * @return false when no more events exist, or on error
+     */
+    bool getNextEvent();
+
+    /**
+     * @brief Parses next event and each of its records into JSON format
+     * @details Writes the audit log events to parsedStream.
+     */
+    void parseEvent();
+
+    /**
+     * @brief Parses and writes next record into JSON format
+     */
+    virtual void parseRecord();
+
+    /**
+     * @brief Parses general audit entry into JSON format
+     * @details Used with audit entries without specific handling. Text of audit
+     * log message is written as-is.
+     */
+    void fillAuditEntry(nlohmann::json& parsedEntry);
+
+    /**
+     * @brief Parses AUDIT_USYS_CONFIG audit entry into JSON format
+     * @details Expected fields from audit log entry are split into MessageArgs
+     */
+    void fillUsysEntry(nlohmann::json& parsedEntry);
+
+    /**
+     * @brief Opens and truncates specified file
+     * @param[in] filePath Path of file to open. File should exist.
+     * @return bool True if stream was established to file, false otherwise.
+     */
+    bool openParsedFile(const std::string& filePath);
+};
+
+/** @class ALParseLatest
+ *  @brief Parsing audit log using auparse library services
+ *  @details Provides means to parse only latest entries
+ */
+class ALParseLatest : public ALParser
+{
+  public:
+    ALParseLatest(const ALParseLatest&) = delete;
+    ALParseLatest& operator=(const ALParseLatest&) = delete;
+    ALParseLatest(ALParseLatest&&) = delete;
+    ALParseLatest& operator=(ALParseLatest&&) = delete;
+
+    /** @brief Constructor to initialize parsing of audit log files
+     *  @param[in] maxEvents Maximum number of events to return.
+     *  @param[in] parsedFile Initialized file for holding parsed log events
+     */
+    ALParseLatest(uint32_t maxEvents, ALParseFile& parsedFile) :
+        ALParser(parsedFile)
+    {
+        lg2::debug("Constructing ALParseLatest: {MAXCOUNT}", "MAXCOUNT",
+                   maxEvents);
+
+        initNextLog();
+        maxCount = maxEvents;
+        maxLeftCount = maxEvents;
+
+        if (au == nullptr)
+        {
+            lg2::error("Failed to init auparse");
+            throw sdbusplus::xyz::openbmc_project::Common::Error::
+                InternalFailure();
+        }
+    }
+
+    /**
+     * @brief Process audit events from initialized au source
+     * @details Limits number of entries written to maxCount.
+     */
+    void doParse() override;
+
+  protected:
+    /**
+     * @brief Format audit entries into JSON using message registry form
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatEntry(nlohmann::json& parsedEntry) override
+    {
+        return formatMsgReg(parsedEntry);
+    };
+
+  private:
+    size_t maxCount = 0;
+    size_t maxLeftCount = 0;
+    unsigned int logFileIdx = 0;
+    std::list<std::string> parsedEntries;
+
+    /**
+     * @brief Parses next record into JSON format and adds to list
+     */
+    void parseRecord() override;
+
+    /**
+     * @brief Initializes parser to next audit log available
+     * @details Initializes with the latest audit log first. Each subsequent
+     *         call will initialize with the next oldest audit log file until
+     *         a file cannot be found.
+     * @return bool True if initialization succeeded, false otherwise.
+     */
+    bool initNextLog();
+
+    /**
+     * @brief Writes parsedEntries to parsedStream
+     * @details parsedEntries is cleared after entries are written.
+     * @return size_t Number of entries written.
+     */
+    size_t writeParsedEntries();
+};
+
+/** @class ALParseAll
+ *  @brief Parsing audit log using auparse library services
+ *  @details Provides means to parse all entries
+ */
+class ALParseAll : public ALParser
+{
+  public:
+    ALParseAll(const ALParseAll&) = delete;
+    ALParseAll& operator=(const ALParseAll&) = delete;
+    ALParseAll(ALParseAll&&) = delete;
+    ALParseAll& operator=(ALParseAll&&) = delete;
+
+    /** @brief Constructor to initialize parsing of audit log files
+     *  @details Initializes au to parse all audit logs.
+     *  @param[in] parsedFile Initialized file for holding parsed log events
+     */
+    explicit ALParseAll(ALParseFile& parsedFile) : ALParser(parsedFile)
+    {
+        lg2::debug("Constructing ALParseAll");
+        au = auparse_init(AUSOURCE_LOGS, nullptr);
+        if (au == nullptr)
+        {
+            lg2::error("Failed to init auparse");
+            throw sdbusplus::xyz::openbmc_project::Common::Error::
+                InternalFailure();
+        }
+    }
+
+  protected:
+    /**
+     * @brief Format audit entries into general JSON
+     * @param[in,out] parsedEntry Filled in with parsed audit entry.
+     * @return bool True if parsing succeeded, false otherwise.
+     */
+    bool formatEntry(nlohmann::json& parsedEntry) override
+    {
+        return formatGeneral(parsedEntry);
+    };
+};
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/alog_utils.hpp
+++ b/phosphor-auditlog/alog_utils.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <libaudit.h>
+
+#include <phosphor-logging/lg2.hpp>
+#include <xyz/openbmc_project/Common/File/error.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace phosphor::auditlog
+{
+
+/** @class ALParseFile
+ *  @brief Creation of temporary file for parsed audit log
+ */
+class ALParseFile
+{
+  public:
+    ALParseFile(const ALParseFile&) = delete;
+    ALParseFile& operator=(const ALParseFile&) = delete;
+    ALParseFile(ALParseFile&&) = delete;
+    ALParseFile& operator=(ALParseFile&&) = delete;
+
+    ~ALParseFile()
+    {
+        if (!pathName.empty() && !keepFile)
+        {
+            lg2::debug("Removing {FILE}", "FILE", pathName);
+            std::filesystem::remove(pathName);
+        }
+    }
+
+    /** @brief Create empty temporary file
+     */
+    ALParseFile()
+    {
+        std::string tempFile = std::filesystem::temp_directory_path() /
+                               "auditLogJson-XXXXXX";
+
+        lg2::debug("Constructing ALParseFile template={NAME}", "NAME",
+                   tempFile);
+
+        int fd = mkstemp(tempFile.data());
+        if (fd == -1)
+        {
+            throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+        }
+
+        // Store path to temporary file
+        pathName = tempFile;
+
+        // Close file descriptor
+        if (close(fd) == -1)
+        {
+            // Delete temporary file.  The destructor won't be called because
+            // the exception below causes this constructor to exit without
+            // completing.
+            std::filesystem::remove(pathName);
+            throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+        }
+    }
+
+    /** @brief Create parsed file that is not removed on destruction
+     *  @details Used for debug only
+     *  @param[in] filePath Path to file to be created. File will be truncated
+     *             if it exists.
+     */
+    explicit ALParseFile(const std::string& filePath)
+    {
+        std::ofstream parsedStream;
+        std::error_code ec;
+
+        // Create/Open file using trunc
+        parsedStream.open(filePath, std::ios::trunc);
+        if (parsedStream.fail())
+        {
+            lg2::error("Failed to open {FILE}", "FILE", filePath);
+            throw sdbusplus::xyz::openbmc_project::Common::File::Error::Open();
+        }
+
+        // Set permissions on file created to match audit.log, 600
+        std::filesystem::perms permission = std::filesystem::perms::owner_read |
+                                            std::filesystem::perms::owner_write;
+        std::filesystem::permissions(filePath, permission);
+
+        pathName = filePath;
+        keepFile = true;
+    }
+
+    /**
+     * @brief Return path of file
+     */
+    const std::string& getPath() const
+    {
+        return pathName;
+    }
+
+  private:
+    std::string pathName;
+    bool keepFile = false; // Don't remove file on destruction
+};
+
+} // namespace phosphor::auditlog

--- a/phosphor-auditlog/main.cpp
+++ b/phosphor-auditlog/main.cpp
@@ -1,0 +1,32 @@
+#include "config.h"
+
+#include "config_main.h"
+
+#include "alog_manager.hpp"
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/manager.hpp>
+
+// AUDITLOG_PATH
+constexpr auto auditLogMgrRoot = "/xyz/openbmc_project/logging/auditlog";
+// AUDITLOG_INTERFACE
+constexpr auto auditLogBusName = "xyz.openbmc_project.Logging.AuditLog";
+
+int main(int /*argc*/, char* /*argv*/[])
+{
+    auto bus = sdbusplus::bus::new_default();
+    auto event = sdeventplus::Event::get_default();
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+
+    sdbusplus::server::manager_t objManager{bus, auditLogMgrRoot};
+
+    // Reserve the dbus service name
+    bus.request_name(auditLogBusName);
+
+    phosphor::auditlog::ALManager alMgr(bus, auditLogMgrRoot);
+
+    // Handle dbus processing forever.
+    event.loop();
+
+    return 0;
+}

--- a/phosphor-auditlog/meson.build
+++ b/phosphor-auditlog/meson.build
@@ -1,5 +1,5 @@
 auditd_dep = dependency('audit')
-ausparse_dep = dependency('auparse', required: true)
+auparse_dep = dependency('auparse', required: true)
 
 auditlog_sources = [
         files(
@@ -28,7 +28,7 @@ executable('phosphor-auditlog',
         sdbusplus_dep,
         sdeventplus_dep,
         auditd_dep,
-        ausparse_dep,
+        auparse_dep,
     ],
     install: true,
 )

--- a/phosphor-auditlog/meson.build
+++ b/phosphor-auditlog/meson.build
@@ -1,0 +1,34 @@
+auditd_dep = dependency('audit')
+ausparse_dep = dependency('auparse', required: true)
+
+auditlog_sources = [
+        files(
+        'main.cpp',
+        'alog_manager.cpp',
+        'alog_parser.cpp',
+        )
+]
+
+extra_args = []
+
+# Add for in-depth debug, too much for normal use
+# extra_args += ['-DAUDITLOG_FULL_DEBUG',]
+
+# Add to keep JSON file around on exit of method
+# extra_args += ['-DAUDITLOG_KEEP_JSONFILE',]
+
+executable('phosphor-auditlog',
+    auditlog_sources,
+    include_directories: include_directories('..'),
+    cpp_args: extra_args,
+    dependencies: [
+        conf_h_dep,
+        phosphor_logging_dep,
+        pdi_dep,
+        sdbusplus_dep,
+        sdeventplus_dep,
+        auditd_dep,
+        ausparse_dep,
+    ],
+    install: true,
+)

--- a/phosphor-rsyslog-config/server-conf.cpp
+++ b/phosphor-rsyslog-config/server-conf.cpp
@@ -87,8 +87,8 @@ std::optional<
                 // There is no ':', or no more content after ':', invalid config
                 return {};
             }
-            serverAddress = line.substr(posColonLeft + 1,
-                                        posColonRight - posColonLeft - 1);
+            serverAddress =
+                line.substr(posColonLeft + 1, posColonRight - posColonLeft - 1);
             serverPort = line.substr(posColonRight + 2);
         }
         else

--- a/test/elog_errorwrap_test.hpp
+++ b/test/elog_errorwrap_test.hpp
@@ -70,7 +70,7 @@ class MockJournal : public Manager
 {
   public:
     MockJournal(sdbusplus::bus_t& bus, const char* objPath) :
-        Manager(bus, objPath){};
+        Manager(bus, objPath) {};
     MOCK_METHOD0(journalSync, void());
     MOCK_METHOD2(sd_journal_open, int(sd_journal**, int));
     MOCK_METHOD4(sd_journal_get_data,

--- a/test/openpower-pels/device_callouts_test.cpp
+++ b/test/openpower-pels/device_callouts_test.cpp
@@ -519,9 +519,9 @@ TEST_F(DeviceCalloutsTest, getCalloutsTest)
             "slave@01:00/01:01:00:06/sbefifo2-dev0/occ-hwmon.2",
             systemTypes);
 
-        std::vector<Callout> expected{{"H", "P1-C19",
-                                       "/chassis/motherboard/cpu0", "core",
-                                       "FSI: links: 0-1 dest: proc-0 target"}};
+        std::vector<Callout> expected{
+            {"H", "P1-C19", "/chassis/motherboard/cpu0", "core",
+             "FSI: links: 0-1 dest: proc-0 target"}};
 
         EXPECT_EQ(callouts, expected);
 

--- a/test/openpower-pels/failing_mtms_test.cpp
+++ b/test/openpower-pels/failing_mtms_test.cpp
@@ -84,10 +84,10 @@ TEST(FailingMTMSTest, ConstructorTest)
 
 TEST(FailingMTMSTest, StreamConstructorTest)
 {
-    std::vector<uint8_t> data{0x4D, 0x54, 0x00, 0x1C, 0x01, 0x00, 0x20,
-                              0x00, 'T',  'T',  'T',  'T',  '-',  'M',
-                              'M',  'M',  '1',  '2',  '3',  '4',  '5',
-                              '6',  '7',  '8',  '9',  'A',  'B',  'C'};
+    std::vector<uint8_t> data{
+        0x4D, 0x54, 0x00, 0x1C, 0x01, 0x00, 0x20, 0x00, 'T', 'T',
+        'T',  'T',  '-',  'M',  'M',  'M',  '1',  '2',  '3', '4',
+        '5',  '6',  '7',  '8',  '9',  'A',  'B',  'C'};
     Stream stream{data};
     FailingMTMS fm{stream};
 
@@ -117,10 +117,10 @@ TEST(FailingMTMSTest, BadStreamConstructorTest)
 
 TEST(FailingMTMSTest, FlattenTest)
 {
-    std::vector<uint8_t> data{0x4D, 0x54, 0x00, 0x1C, 0x01, 0x00, 0x20,
-                              0x00, 'T',  'T',  'T',  'T',  '-',  'M',
-                              'M',  'M',  '1',  '2',  '3',  '4',  '5',
-                              '6',  '7',  '8',  '9',  'A',  'B',  'C'};
+    std::vector<uint8_t> data{
+        0x4D, 0x54, 0x00, 0x1C, 0x01, 0x00, 0x20, 0x00, 'T', 'T',
+        'T',  'T',  '-',  'M',  'M',  'M',  '1',  '2',  '3', '4',
+        '5',  '6',  '7',  '8',  '9',  'A',  'B',  'C'};
     Stream stream{data};
     FailingMTMS fm{stream};
 

--- a/test/openpower-pels/host_notifier_test.cpp
+++ b/test/openpower-pels/host_notifier_test.cpp
@@ -47,8 +47,8 @@ class HostNotifierTest : public CleanPELFiles
 
         ON_CALL(dataIface, getHostPELEnablement).WillByDefault(Return(true));
 
-        hostIface = std::make_unique<NiceMock<MockHostInterface>>(event,
-                                                                  dataIface);
+        hostIface =
+            std::make_unique<NiceMock<MockHostInterface>>(event, dataIface);
 
         mockHostIface = reinterpret_cast<MockHostInterface*>(hostIface.get());
 
@@ -121,11 +121,11 @@ TEST_F(HostNotifierTest, TestHostStateChange)
 {
     bool hostState = false;
     bool called = false;
-    DataInterfaceBase::HostStateChangeFunc func = [&hostState,
-                                                   &called](bool state) {
-        hostState = state;
-        called = true;
-    };
+    DataInterfaceBase::HostStateChangeFunc func =
+        [&hostState, &called](bool state) {
+            hostState = state;
+            called = true;
+        };
 
     dataIface.subscribeToHostStateChange("test", func);
 

--- a/test/openpower-pels/meson.build
+++ b/test/openpower-pels/meson.build
@@ -71,7 +71,6 @@ openpower_test_lib = static_library(
     libpel_sources,
     peltool_sources,
     '../common.cpp',
-    '../../util.cpp',
     include_directories: include_directories(
         '../../',
         '../../gen',

--- a/test/openpower-pels/mocks.hpp
+++ b/test/openpower-pels/mocks.hpp
@@ -66,6 +66,8 @@ class MockDataInterface : public DataInterfaceBase
     MOCK_METHOD(std::vector<uint32_t>, getLogIDWithHwIsolation, (),
                 (const override));
     MOCK_METHOD(std::vector<uint8_t>, getRawProgressSRC, (), (const override));
+    MOCK_METHOD(std::optional<std::vector<uint8_t>>, getDIProperty,
+                (const std::string&), (const override));
 
     void changeHostState(bool newState)
     {

--- a/test/openpower-pels/pel_manager_test.cpp
+++ b/test/openpower-pels/pel_manager_test.cpp
@@ -392,11 +392,11 @@ TEST_F(ManagerTest, TestDBusMethods)
 
     std::unique_ptr<JournalBase> journal = std::make_unique<MockJournal>();
 
-    Manager manager{logManager, std::move(dataIface),
-                    std::bind(std::mem_fn(&TestLogger::log), &logger,
-                              std::placeholders::_1, std::placeholders::_2,
-                              std::placeholders::_3),
-                    std::move(journal)};
+    Manager manager{
+        logManager, std::move(dataIface),
+        std::bind(std::mem_fn(&TestLogger::log), &logger, std::placeholders::_1,
+                  std::placeholders::_2, std::placeholders::_3),
+        std::move(journal)};
 
     // Create a PEL, write it to a file, and pass that filename into
     // the create function so there's one in the repo.

--- a/test/openpower-pels/pel_test.cpp
+++ b/test/openpower-pels/pel_test.cpp
@@ -211,9 +211,10 @@ TEST_F(PELTest, CreateFromRegistryTest)
         // in the registry, so the constructor should set them.
         regEntry.actionFlags = std::nullopt;
 
-        PEL pel2{
-            regEntry, 42,   timestamp, phosphor::logging::Entry::Level::Error,
-            ad,       ffdc, dataIface, journal};
+        PEL pel2{regEntry,  42,
+                 timestamp, phosphor::logging::Entry::Level::Error,
+                 ad,        ffdc,
+                 dataIface, journal};
 
         EXPECT_EQ(pel2.userHeader().actionFlags(), 0xA800);
     }
@@ -251,11 +252,11 @@ TEST_F(PELTest, CreateTooBigADTest)
 
     // Make sure that there are still 2 UD sections.
     const auto& optSections = pel.optionalSections();
-    auto udCount = std::count_if(optSections.begin(), optSections.end(),
-                                 [](const auto& section) {
-        return section->header().id ==
-               static_cast<uint16_t>(SectionID::userData);
-    });
+    auto udCount = std::count_if(
+        optSections.begin(), optSections.end(), [](const auto& section) {
+            return section->header().id ==
+                   static_cast<uint16_t>(SectionID::userData);
+        });
 
     EXPECT_EQ(udCount, 2); // AD section and sysInfo section
 }
@@ -266,15 +267,15 @@ TEST_F(PELTest, GenericSectionTest)
 {
     auto data = pelDataFactory(TestPELType::pelSimple);
 
-    std::vector<uint8_t> section1{0x58, 0x58, // ID 'XX'
-                                  0x00, 0x18, // Size
-                                  0x01, 0x02, // version, subtype
-                                  0x03, 0x04, // comp ID
+    std::vector<uint8_t> section1{
+        0x58, 0x58, // ID 'XX'
+        0x00, 0x18, // Size
+        0x01, 0x02, // version, subtype
+        0x03, 0x04, // comp ID
 
-                                  // some data
-                                  0x20, 0x30, 0x05, 0x09, 0x11, 0x1E, 0x1, 0x63,
-                                  0x20, 0x31, 0x06, 0x0F, 0x09, 0x22, 0x3A,
-                                  0x00};
+        // some data
+        0x20, 0x30, 0x05, 0x09, 0x11, 0x1E, 0x1, 0x63, 0x20, 0x31, 0x06, 0x0F,
+        0x09, 0x22, 0x3A, 0x00};
 
     std::vector<uint8_t> section2{
         0x59, 0x59, // ID 'YY'
@@ -848,10 +849,10 @@ TEST_F(PELTest, CreateWithDevCalloutsTest)
         .WillOnce(Return(std::vector<std::string>{
             "/xyz/openbmc_project/inventory/chassis/motherboard/cpu0"}));
 
-    EXPECT_CALL(
-        dataIface,
-        getHWCalloutFields(
-            "/xyz/openbmc_project/inventory/chassis/motherboard/cpu0", _, _, _))
+    EXPECT_CALL(dataIface,
+                getHWCalloutFields(
+                    "/xyz/openbmc_project/inventory/chassis/motherboard/cpu0",
+                    _, _, _))
         .WillOnce(DoAll(SetArgReferee<1>("1234567"), SetArgReferee<2>("CCCC"),
                         SetArgReferee<3>("123456789ABC")));
 
@@ -868,9 +869,10 @@ TEST_F(PELTest, CreateWithDevCalloutsTest)
 
         AdditionalData ad{data};
 
-        PEL pel{
-            regEntry, 42,   timestamp, phosphor::logging::Entry::Level::Error,
-            ad,       ffdc, dataIface, journal};
+        PEL pel{regEntry,  42,
+                timestamp, phosphor::logging::Entry::Level::Error,
+                ad,        ffdc,
+                dataIface, journal};
 
         ASSERT_TRUE(pel.primarySRC().value()->callouts());
         auto& callouts = pel.primarySRC().value()->callouts()->callouts();
@@ -918,9 +920,10 @@ TEST_F(PELTest, CreateWithDevCalloutsTest)
 
         AdditionalData ad{data};
 
-        PEL pel{
-            regEntry, 42,   timestamp, phosphor::logging::Entry::Level::Error,
-            ad,       ffdc, dataIface, journal};
+        PEL pel{regEntry,  42,
+                timestamp, phosphor::logging::Entry::Level::Error,
+                ad,        ffdc,
+                dataIface, journal};
 
         // no callouts
         EXPECT_FALSE(pel.primarySRC().value()->callouts());
@@ -1157,9 +1160,10 @@ TEST_F(PELTest, CaptureJournalTest)
 
         EXPECT_CALL(journal, getMessages("", 5)).WillOnce(Return(msgs));
 
-        PEL pel{
-            regEntry, 42,   timestamp, phosphor::logging::Entry::Level::Error,
-            ad,       ffdc, dataIface, journal};
+        PEL pel{regEntry,  42,
+                timestamp, phosphor::logging::Entry::Level::Error,
+                ad,        ffdc,
+                dataIface, journal};
 
         // Check the generated UserData section
         std::string expected{"test1 test2\ntest3 test4\ntest5 test6\n4\n5\n"};
@@ -1183,9 +1187,10 @@ TEST_F(PELTest, CaptureJournalTest)
             .WillOnce(
                 Return(std::vector<std::string>{std::string(20000, 'x')}));
 
-        PEL pel{
-            regEntry, 42,   timestamp, phosphor::logging::Entry::Level::Error,
-            ad,       ffdc, dataIface, journal};
+        PEL pel{regEntry,  42,
+                timestamp, phosphor::logging::Entry::Level::Error,
+                ad,        ffdc,
+                dataIface, journal};
 
         // Check for 1 fewer sections than in the previous PEL
         EXPECT_EQ(pel.privateHeader().sectionCount(), pelSectsWithOneUD - 1);
@@ -1214,9 +1219,10 @@ TEST_F(PELTest, CaptureJournalTest)
         EXPECT_CALL(journal, getMessages("app2", 4)).WillOnce(Return(app2));
         EXPECT_CALL(journal, getMessages("app3", 1)).WillOnce(Return(app3));
 
-        PEL pel{
-            regEntry, 42,   timestamp, phosphor::logging::Entry::Level::Error,
-            ad,       ffdc, dataIface, journal};
+        PEL pel{regEntry,  42,
+                timestamp, phosphor::logging::Entry::Level::Error,
+                ad,        ffdc,
+                dataIface, journal};
 
         // Two more sections than the 1 extra UD section in the first testcase
         ASSERT_EQ(pel.privateHeader().sectionCount(), pelSectsWithOneUD + 2);
@@ -1250,9 +1256,10 @@ TEST_F(PELTest, CaptureJournalTest)
             .WillOnce(
                 Return(std::vector<std::string>{std::string(20000, 'x')}));
 
-        PEL pel{
-            regEntry, 42,   timestamp, phosphor::logging::Entry::Level::Error,
-            ad,       ffdc, dataIface, journal};
+        PEL pel{regEntry,  42,
+                timestamp, phosphor::logging::Entry::Level::Error,
+                ad,        ffdc,
+                dataIface, journal};
 
         // The last section should have been dropped, so same as first TC
         ASSERT_EQ(pel.privateHeader().sectionCount(), pelSectsWithOneUD);

--- a/test/openpower-pels/registry_test.cpp
+++ b/test/openpower-pels/registry_test.cpp
@@ -269,8 +269,8 @@ TEST_F(RegistryTest, TestFindEntryMinimal)
     auto path = RegistryTest::writeData(registryData);
     Registry registry{path};
 
-    auto entry = registry.lookup("xyz.openbmc_project.Power.Fault",
-                                 LookupType::name);
+    auto entry =
+        registry.lookup("xyz.openbmc_project.Power.Fault", LookupType::name);
     ASSERT_TRUE(entry);
     EXPECT_EQ(entry->name, "xyz.openbmc_project.Power.Fault");
     EXPECT_EQ(entry->subsystem, 0x61);
@@ -407,8 +407,8 @@ TEST_F(RegistryTest, TestGetComponentID)
     using namespace openpower::pels::message::helper;
 
     // Get it from the JSON
-    auto id = getComponentID(0xBD, 0x4200, R"({"ComponentID":"0x4200"})"_json,
-                             "foo");
+    auto id =
+        getComponentID(0xBD, 0x4200, R"({"ComponentID":"0x4200"})"_json, "foo");
     EXPECT_EQ(id, 0x4200);
 
     // Get it from the reason code on a 0xBD SRC

--- a/test/openpower-pels/src_callout_test.cpp
+++ b/test/openpower-pels/src_callout_test.cpp
@@ -284,9 +284,9 @@ TEST(CalloutTest, TestHardwareCallout)
         Callout callout{CalloutPriority::high, "U99-P5", "1234567", "ABCD",
                         "123456789ABC",        mruList};
 
-        EXPECT_EQ(callout.flags(), Callout::calloutType |
-                                       Callout::fruIdentIncluded |
-                                       Callout::mruIncluded);
+        EXPECT_EQ(callout.flags(),
+                  Callout::calloutType | Callout::fruIdentIncluded |
+                      Callout::mruIncluded);
 
         EXPECT_EQ(callout.priority(), 'H');
         EXPECT_EQ(callout.locationCode(), "U99-P5");

--- a/test/openpower-pels/src_test.cpp
+++ b/test/openpower-pels/src_test.cpp
@@ -624,9 +624,9 @@ TEST_F(SRCTest, RegistryCalloutTest)
                 "/xyz/openbmc_project/inventory/chassis/motherboard/cpu0", _, _,
                 _))
             .Times(1)
-            .WillOnce(DoAll(SetArgReferee<1>("1234567"),
-                            SetArgReferee<2>("CCCC"),
-                            SetArgReferee<3>("123456789ABC")));
+            .WillOnce(
+                DoAll(SetArgReferee<1>("1234567"), SetArgReferee<2>("CCCC"),
+                      SetArgReferee<3>("123456789ABC")));
 
         EXPECT_CALL(
             dataIface,
@@ -634,9 +634,9 @@ TEST_F(SRCTest, RegistryCalloutTest)
                 "/xyz/openbmc_project/inventory/chassis/motherboard/cpu1", _, _,
                 _))
             .Times(1)
-            .WillOnce(DoAll(SetArgReferee<1>("2345678"),
-                            SetArgReferee<2>("DDDD"),
-                            SetArgReferee<3>("23456789ABCD")));
+            .WillOnce(
+                DoAll(SetArgReferee<1>("2345678"), SetArgReferee<2>("DDDD"),
+                      SetArgReferee<3>("23456789ABCD")));
 
         SRC src{entry, ad, dataIface};
 
@@ -843,30 +843,30 @@ TEST_F(SRCTest, DevicePathCalloutTest)
         .Times(3)
         .WillRepeatedly(Return("Ufcs-P1-C15"));
 
-    EXPECT_CALL(
-        dataIface,
-        getHWCalloutFields(
-            "/xyz/openbmc_project/inventory/chassis/motherboard/cpu0", _, _, _))
+    EXPECT_CALL(dataIface,
+                getHWCalloutFields(
+                    "/xyz/openbmc_project/inventory/chassis/motherboard/cpu0",
+                    _, _, _))
         .Times(3)
-        .WillRepeatedly(DoAll(SetArgReferee<1>("1234567"),
-                              SetArgReferee<2>("CCCC"),
-                              SetArgReferee<3>("123456789ABC")));
+        .WillRepeatedly(
+            DoAll(SetArgReferee<1>("1234567"), SetArgReferee<2>("CCCC"),
+                  SetArgReferee<3>("123456789ABC")));
     EXPECT_CALL(
         dataIface,
         getHWCalloutFields("/xyz/openbmc_project/inventory/chassis/motherboard",
                            _, _, _))
         .Times(3)
-        .WillRepeatedly(DoAll(SetArgReferee<1>("7654321"),
-                              SetArgReferee<2>("MMMM"),
-                              SetArgReferee<3>("CBA987654321")));
-    EXPECT_CALL(
-        dataIface,
-        getHWCalloutFields(
-            "/xyz/openbmc_project/inventory/chassis/motherboard/bmc", _, _, _))
+        .WillRepeatedly(
+            DoAll(SetArgReferee<1>("7654321"), SetArgReferee<2>("MMMM"),
+                  SetArgReferee<3>("CBA987654321")));
+    EXPECT_CALL(dataIface,
+                getHWCalloutFields(
+                    "/xyz/openbmc_project/inventory/chassis/motherboard/bmc", _,
+                    _, _))
         .Times(3)
-        .WillRepeatedly(DoAll(SetArgReferee<1>("7123456"),
-                              SetArgReferee<2>("BBBB"),
-                              SetArgReferee<3>("C123456789AB")));
+        .WillRepeatedly(
+            DoAll(SetArgReferee<1>("7123456"), SetArgReferee<2>("BBBB"),
+                  SetArgReferee<3>("C123456789AB")));
 
     // Call this below with different AdditionalData values that
     // result in the same callouts.
@@ -1042,9 +1042,9 @@ TEST_F(SRCTest, JsonCalloutsTest)
             dataIface,
             getHWCalloutFields("/inv/system/chassis/motherboard/bmc", _, _, _))
             .Times(1)
-            .WillOnce(DoAll(SetArgReferee<1>("1234567"),
-                            SetArgReferee<2>("CCCC"),
-                            SetArgReferee<3>("123456789ABC")));
+            .WillOnce(
+                DoAll(SetArgReferee<1>("1234567"), SetArgReferee<2>("CCCC"),
+                      SetArgReferee<3>("123456789ABC")));
     }
     // Callout 1 mock calls
     {
@@ -1055,9 +1055,9 @@ TEST_F(SRCTest, JsonCalloutsTest)
             dataIface,
             getHWCalloutFields("/inv/system/chassis/motherboard/cpu0", _, _, _))
             .Times(1)
-            .WillOnce(DoAll(SetArgReferee<1>("2345678"),
-                            SetArgReferee<2>("DDDD"),
-                            SetArgReferee<3>("23456789ABCD")));
+            .WillOnce(
+                DoAll(SetArgReferee<1>("2345678"), SetArgReferee<2>("DDDD"),
+                      SetArgReferee<3>("23456789ABCD")));
     }
     // Callout 3 mock calls
     {
@@ -1230,9 +1230,9 @@ TEST_F(SRCTest, JsonBadCalloutsTest)
             dataIface,
             getHWCalloutFields("/inv/system/chassis/motherboard/bmc", _, _, _))
             .Times(1)
-            .WillOnce(DoAll(SetArgReferee<1>("1234567"),
-                            SetArgReferee<2>("CCCC"),
-                            SetArgReferee<3>("123456789ABC")));
+            .WillOnce(
+                DoAll(SetArgReferee<1>("1234567"), SetArgReferee<2>("CCCC"),
+                      SetArgReferee<3>("123456789ABC")));
     }
 
     // Callout 1 mock calls

--- a/test/openpower-pels/user_data_test.cpp
+++ b/test/openpower-pels/user_data_test.cpp
@@ -20,14 +20,14 @@
 
 using namespace openpower::pels;
 
-std::vector<uint8_t> udSectionData{0x55, 0x44, // ID 'UD'
-                                   0x00, 0x10, // Size
-                                   0x01, 0x02, // version, subtype
-                                   0x03, 0x04, // comp ID
+std::vector<uint8_t> udSectionData{
+    0x55, 0x44, // ID 'UD'
+    0x00, 0x10, // Size
+    0x01, 0x02, // version, subtype
+    0x03, 0x04, // comp ID
 
-                                   // Data
-                                   0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
-                                   0x18};
+    // Data
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18};
 
 TEST(UserDataTest, UnflattenFlattenTest)
 {


### PR DESCRIPTION
#### Audit Log: Use named fields for log entries (#64)
```
Changed phosphor-auditlog to create the JSON file with named entries
instead of MessageArgs. Removed understanding of bmcweb message
registry.

Tested:
 - Built with option to retain JSON file and verified objects correct
   using busctl call.
 - Used updated bmcweb to confirm entries understood.
 - Verified audit entry missing fields still results in JSON object
   created and missing field initialized as empty string.

Signed-off-by: Janet Adkins <janeta@us.ibm.com>```