### PR TITLE
PEL: DRAM Fix: Reset JobRemoved signal watcher

### DIFF
--- a/extensions/openpower-pels/data_interface.cpp
+++ b/extensions/openpower-pels/data_interface.cpp
@@ -1171,7 +1171,7 @@ void DataInterface::subscribeToSystemdSignals()
             {
                 auto* error = msg.get_error();
                 lg2::error("Failed to subscribe JobRemoved systemd signal, "
-                           "errorName: {ERR_NAME}, errorMsg: {ERR_MSG}, ",
+                           "errorName: {ERR_NAME}, errorMsg: {ERR_MSG} ",
                            "ERR_NAME", error->name, "ERR_MSG", error->message);
                 return;
             }
@@ -1194,10 +1194,11 @@ void DataInterface::subscribeToSystemdSignals()
                      "openpower-update-bios-attr-table.service") &&
                     (jobUnitResult == "done"))
                 {
-                    // Unsubscribe immediately after the signal is
-                    // received to avoid unwanted signal
-                    // reception. And initialize PHAL once the
-                    // unsubscription is success.
+#ifdef PEL_ENABLE_PHAL
+                    this->initPHAL();
+#endif
+                    // Invoke unsubscribe method to stop monitoring for
+                    // JobRemoved signals.
                     this->unsubscribeFromSystemdSignals();
                 }
             });
@@ -1227,13 +1228,13 @@ void DataInterface::unsubscribeFromSystemdSignals()
                 auto* error = msg.get_error();
                 lg2::error(
                     "Failed to unsubscribe from JobRemoved systemd signal, "
-                    "errorName: {ERR_NAME}, errorMsg: {ERR_MSG}, ",
+                    "errorName: {ERR_NAME}, errorMsg: {ERR_MSG} ",
                     "ERR_NAME", error->name, "ERR_MSG", error->message);
                 return;
             }
-#ifdef PEL_ENABLE_PHAL
-            this->initPHAL();
-#endif
+            // Reset _systemdMatch to avoid reception of further JobRemoved
+            // signals
+            this->_systemdMatch.reset();
         });
     }
     catch (const sdbusplus::exception_t& e)


### PR DESCRIPTION
It is observed in journal traces that that the phosphor-log-manager is receiving error trace as 'Failed to unsubscribe from JobRemoved systemd signal' during host factory reset

Root cause:
- It is observed that the systemd service `openpower-update-bios-attr-table.service` is starting again during host factory reset which is responsible for the PNOR symlink creation and update.
- In the existing code `JobRemoved` signal is subscribed for `openpower-update-bios-attr-table.service`
- In systemd signal , if at least one client is subscribed for a signal, most of the signals will sent out to the clients even if the current client unsubscribed.
- Since many other service including phosphor-state-manager is also subscribed for the signal and is not unsubscribed. Hence Phosphor-logging is getting `JobRemoved` again even if it is unsubscribed after PHAL initialization.

Fix proposed:
- The issue is fixed by resetting the JobRemoved signal watcher

Other changes as part of this commit:
- Removing an unwanted comma in 2 lg2 traces in the file `data_interface.cpp`
- The PHAL initialization point is changed so that `Unsubscribe` method will invoke after PHAL initialization.

Tested:

Tested the approach and verified that no further JobRemoved signals are receiving by monitoring journal traces.

```
systemd[1]: Starting Update BIOS attr table with host firmware
            well-known names...
systemd[1]: openpower-update-bios-attr-table.service:
            Deactivated successfully.
systemd[1]: Finished Update BIOS attr table with host firmware
            well-known names.
pldmd[1104]: BIOS attribute 'hb_lid_ids' updated to value
systemd[1]: Starting OpenPOWER Host HardwareIsolation...
systemd[1]: Started OpenPOWER Host HardwareIsolation.
```

Change-Id: Ib273397c7303a0473ca12e3879d154a39138de02