### PR TITLE
openpower-pels: Create guard using libguard

### DIFF
--- a/extensions/openpower-pels/data_interface.hpp
+++ b/extensions/openpower-pels/data_interface.hpp
@@ -3,6 +3,11 @@
 #include "dbus_types.hpp"
 #include "dbus_watcher.hpp"
 
+#ifdef PEL_ENABLE_PHAL
+#include <libguard/guard_interface.hpp>
+#include <libguard/include/guard_record.hpp>
+#endif
+
 #include <phosphor-logging/lg2.hpp>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/bus/match.hpp>
@@ -11,6 +16,11 @@
 #include <filesystem>
 #include <fstream>
 #include <unordered_map>
+
+#ifdef PEL_ENABLE_PHAL
+using GardType = openpower::guard::GardType;
+namespace libguard = openpower::guard;
+#endif
 
 namespace openpower
 {
@@ -443,16 +453,17 @@ class DataInterfaceBase
     static std::pair<std::string, std::string>
         extractConnectorFromLocCode(const std::string& locationCode);
 
+#ifdef PEL_ENABLE_PHAL
     /**
      * @brief Create guard record
      *
      *  @param[in] binPath: phal devtree binary path used as key
-     *  @param[in] type: Guard type
-     *  @param[in] logPath: error log entry object path
+     *  @param[in] eGardType: Guard type enum value
+     *  @param[in] plid: Pel ID
      */
     virtual void createGuardRecord(const std::vector<uint8_t>& binPath,
-                                   const std::string& type,
-                                   const std::string& logPath) const = 0;
+                                   GardType eGardType, uint32_t plid) const = 0;
+#endif
 
     /**
      * @brief Create Progress SRC property on the boot progress
@@ -856,16 +867,17 @@ class DataInterface : public DataInterfaceBase
      */
     bool getQuiesceOnError() const override;
 
+#ifdef PEL_ENABLE_PHAL
     /**
      * @brief Create guard record
      *
      *  @param[in] binPath: phal devtree binary path used as key
-     *  @param[in] type: Guard type
-     *  @param[in] logPath: error log entry object path
+     *  @param[in] eGardType: Guard type enum value
+     *   @param[in] plid: pel id to be associated to the guard record
      */
     void createGuardRecord(const std::vector<uint8_t>& binPath,
-                           const std::string& type,
-                           const std::string& logPath) const override;
+                           GardType eGardType, uint32_t plid) const override;
+#endif
 
     /**
      * @brief Create Progress SRC property on the boot progress

--- a/extensions/openpower-pels/meson.build
+++ b/extensions/openpower-pels/meson.build
@@ -32,6 +32,7 @@ if build_phal
         cpp.find_library('pdbg'),
         cpp.find_library('ekb'),
         cpp.find_library('phal'),
+        cpp.find_library('libguard'),
     ]
     extra_args += [
         '-DPEL_ENABLE_PHAL',

--- a/extensions/openpower-pels/pel.cpp
+++ b/extensions/openpower-pels/pel.cpp
@@ -34,6 +34,11 @@
 #ifdef PEL_ENABLE_PHAL
 #include "phal_service_actions.hpp"
 #include "sbe_ffdc_handler.hpp"
+
+#include <libguard/guard_interface.hpp>
+#include <libguard/include/guard_record.hpp>
+
+namespace libguard = openpower::guard;
 #endif
 
 #include <sys/stat.h>
@@ -175,8 +180,7 @@ PEL::PEL(const message::Entry& regEntry, uint32_t obmcLogID, uint64_t timestamp,
 
 #ifdef PEL_ENABLE_PHAL
     auto path = std::string(OBJ_ENTRY) + '/' + std::to_string(obmcLogID);
-    openpower::pels::phal::createServiceActions(callouts, path, dataIface,
-                                                plid());
+    openpower::pels::phal::createServiceActions(callouts, dataIface, plid());
 #endif
 
     // Store in the PEL any important debug data created while

--- a/extensions/openpower-pels/phal_service_actions.hpp
+++ b/extensions/openpower-pels/phal_service_actions.hpp
@@ -12,21 +12,15 @@ namespace pels
 namespace phal
 {
 
-using EntrySeverity =
-    sdbusplus::server::xyz::openbmc_project::hardware_isolation::Entry::Type;
-
 /**
  * @brief Helper function to create service actions in the PEL
  *
  * @param[in] jsonCallouts - The array of JSON callouts, or an empty object.
- * @param[in] path - The BMC error log object path
  * @param[in] dataIface - The DataInterface object
  * @param[in] plid -  the PLID
  */
 void createServiceActions(const nlohmann::json& jsonCallouts,
-                          const std::string& path,
-                          const DataInterfaceBase& dataIface,
-                          const uint32_t plid);
+                          const DataInterfaceBase& dataIface, uint32_t plid);
 } // namespace phal
 } // namespace pels
 } // namespace openpower

--- a/phosphor-auditlog/alog_manager.hpp
+++ b/phosphor-auditlog/alog_manager.hpp
@@ -41,7 +41,7 @@ class ALManager : public ALObject
      *  @param[in] path - Path to attach at.
      */
     ALManager(sdbusplus::bus_t& bus, const std::string& path) :
-        ALObject(bus, path.c_str()){};
+        ALObject(bus, path.c_str()) {};
 
     /**
      * @brief Parses all audit log events into JSON format.

--- a/phosphor-auditlog/alog_parser.cpp
+++ b/phosphor-auditlog/alog_parser.cpp
@@ -220,9 +220,9 @@ bool ALParser::formatMsgReg(nlohmann::json& parsedEntry)
         throw sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure();
     }
     parsedEntry["EventTimestamp"] = fullTimestamp->sec;
-    parsedEntry["ID"] = std::format("{}.{}:{}", fullTimestamp->sec,
-                                    fullTimestamp->milli,
-                                    fullTimestamp->serial);
+    parsedEntry["ID"] =
+        std::format("{}.{}:{}", fullTimestamp->sec, fullTimestamp->milli,
+                    fullTimestamp->serial);
 
     /* Fill varied args fields based on record type */
     int recType = auparse_get_type(au);
@@ -259,9 +259,9 @@ bool ALParser::formatGeneral(nlohmann::json& parsedEntry)
         throw sdbusplus::xyz::openbmc_project::Common::Error::InternalFailure();
     }
     parsedEntry["EventTimestamp"] = fullTimestamp->sec;
-    parsedEntry["ID"] = std::format("{}.{}:{}", fullTimestamp->sec,
-                                    fullTimestamp->milli,
-                                    fullTimestamp->serial);
+    parsedEntry["ID"] =
+        std::format("{}.{}:{}", fullTimestamp->sec, fullTimestamp->milli,
+                    fullTimestamp->serial);
 
     auto recMsg = auparse_get_record_text(au);
     parsedEntry["Event"] = recMsg;

--- a/phosphor-auditlog/alog_utils.hpp
+++ b/phosphor-auditlog/alog_utils.hpp
@@ -36,8 +36,8 @@ class ALParseFile
      */
     ALParseFile()
     {
-        std::string tempFile = std::filesystem::temp_directory_path() /
-                               "auditLogJson-XXXXXX";
+        std::string tempFile =
+            std::filesystem::temp_directory_path() / "auditLogJson-XXXXXX";
 
         lg2::debug("Constructing ALParseFile template={NAME}", "NAME",
                    tempFile);


### PR DESCRIPTION
Replace CreateWithEntityPath D-Bus method with guard library calls for creating guard entries, as CreateWithEntityPath is not an approved dbus method.

Tested and the guard record is created with the corresponding PEL id

```
before injecting the error
root@p10bmc:~# guard -l
No unresolved records to display

After injecting error, the guard is created using the PEL ID
root@p10bmc:~# guard -l
ID         | ERROR      | Type            | Path
0x00000001 | 0x5000592b | unrecoverable   | physical:sys-0/node-0/proc-0/eq-1/fc-0/core-0
root@p10bmc:~# peltool -l
{
    "0x5000592B": {
        "SRC":                  "BD13E510",
        "Message":              "Error Signature: 0x20DA0020 0x00000001 0x4D740407",
        "PLID":                 "0x5000592B",
        "CreatorID":            "BMC",
        "Subsystem":            "Processor Unit (CPU)",
        "Commit Time":          "10/17/2024 09:54:22",
        "Sev":                  "Unrecoverable Error",
        "CompID":               "bmc hw diags"
    }
}
```

Upstream commit : https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/75366