### PR TITLE
openpower-pels: Fix libguard initialization

### DIFF
--- a/extensions/openpower-pels/data_interface.cpp
+++ b/extensions/openpower-pels/data_interface.cpp
@@ -234,15 +234,6 @@ DataInterface::DataInterface(sdbusplus::bus_t& bus) :
     {
 #ifdef PEL_ENABLE_PHAL
         initPHAL();
-        try
-        {
-            libguard::libguard_init(false);
-        }
-        catch (libguard::exception::GuardException& e)
-        {
-            lg2::error("Exception to init the guard {ERROR}", "ERROR",
-                       e.what());
-        }
 #endif
     }
     else
@@ -701,11 +692,12 @@ void DataInterface::createGuardRecord(const std::vector<uint8_t>& binPath,
 {
     try
     {
+        libguard::libguard_init(false);
         libguard::create(binPath, plid, eGardType);
     }
     catch (libguard::exception::GuardException& e)
     {
-        lg2::error("Exception to create the guard {ERROR}", "ERROR", e.what());
+        lg2::error("Exception in libguard {ERROR}", "ERROR", e);
     }
 }
 #endif


### PR DESCRIPTION
The initialization of libguard was being skipped because the device tree was not set up during the initial phosphor-logging phase. As a result, all guard library calls failed, preventing the creation of system guards in the event of an error.

To address this, the libguard initialization has been moved to the point where guard creation occurs. Since libguard initialization is lightweight, this change has no noticeable impact on performance.

The fix has been tested, and guards are now correctly created as expected.

```
root@p10bmc:~# putscom pu.c 20018600 8000000000000000 -n0 -p0 -cft
pu.c    k0:n0:s0:p00:c0
/usr/bin/edbg putscom pu.c 20018600 8000000000000000 -n0 -p0 -cft

root@p10bmc:~# guard -l
ID         | ERROR      | Type            | Path
0x00000001 | 0x50000a78 | unrecoverable   | physical:sys-0/node-0/proc-0/eq-0/fc-0/core-0
```
Change-Id: I8c718be4638743dc1015d0f4f327a4f65c9d9c2d