### PR TITLE
openpower-pels: Add BMC0005 callout to pgood error

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -2919,7 +2919,14 @@
                         "Callouts": [
                             {
                                 "CalloutList": [
-                                    { "Priority": "high", "LocCode": "P0-C17" },
+                                    {
+                                        "Priority": "high",
+                                        "Procedure": "BMC0005"
+                                    },
+                                    {
+                                        "Priority": "medium",
+                                        "LocCode": "P0-C17"
+                                    },
                                     {
                                         "Priority": "medium",
                                         "LocCode": "P0-C96"


### PR DESCRIPTION
Add the procedure BMC0005 as a high priority callout for pgood errors on the 3V3IO voltage rail.  Reduce first VRM callout to medium priority.

When the lid (cover) is removed on Everest/Fuji systems, main power is automatically shut off for safety reasons.  Due to the hardware design and UCD configuration, the resulting pgood error is incorrectly isolated to the 3V3IO voltage rail.  Add the BMC0005 procedure as the first callout for this error so the lid will be checked as a possible cause.

Tested:
* Created 11002620 error for the 3V3IO rail using busctl.
* Verified all callouts in the resulting error log were correct.

Change-Id: I3af8ce6ae146ff8c6816602a2bfa47e679268387