### PR TITLE
Add a new error message for Dump Offload

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6133,8 +6133,8 @@
                 "Words6To9": {}
             },
             "Documentation": {
-                "Description": "Dump has been deleted/offloaded",
-                "Message": "BMC/System/Resource dump has been deleted/offloaded"
+                "Description": "Dump has been deleted",
+                "Message": "BMC/System/Resource dump has been deleted"
             }
         },
         {
@@ -6198,6 +6198,20 @@
             "Documentation": {
                 "Description": "Failed to decode NewFileAvailable response",
                 "Message": "Failed to decode NewFileAvailable response"
+            }
+        },
+        {
+            "Name": "xyz.openbmc_project.Dump.Error.Offload",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x6000",
+            "Severity": "non_error",
+            "SRC": {
+                "ReasonCode": "0x6029",
+                "Words6To9": {}
+            },
+            "Documentation": {
+                "Description": "Dump has been offloaded",
+                "Message": "BMC/System/Resource dump has been offloaded"
             }
         },
         {


### PR DESCRIPTION
We log the same error for Dump Delete and Offload right now. Adding a new error to distinguish between a dump delete and a dump offload.

Change-Id: I19282b3e7971702b6b3756aaf060ceeb200d2f94