### PR TITLE
PELs: Use pldm_msg_hdr_correlate_response()

### DIFF
--- a/extensions/openpower-pels/pldm_interface.hpp
+++ b/extensions/openpower-pels/pldm_interface.hpp
@@ -215,6 +215,11 @@ class PLDMInterface : public HostInterface
     pldm_transport* pldmTransport = nullptr;
 
     pldm_transport_mctp_demux* mctpDemux = nullptr;
+
+    /**
+     * @brief The header for the most recent request.
+     */
+    pldm_msg_hdr _requestHeader{};
 };
 
 } // namespace openpower::pels

--- a/log_manager.cpp
+++ b/log_manager.cpp
@@ -195,10 +195,10 @@ void Manager::_commit(uint64_t transactionId [[maybe_unused]],
     createEntry(errMsg, errLvl, additionalData);
 }
 
-auto Manager::createEntry(
-    std::string errMsg, Entry::Level errLvl,
-    std::vector<std::string> additionalData,
-    const FFDCEntries& ffdc) -> sdbusplus::message::object_path
+auto Manager::createEntry(std::string errMsg, Entry::Level errLvl,
+                          std::vector<std::string> additionalData,
+                          const FFDCEntries& ffdc)
+    -> sdbusplus::message::object_path
 {
     if (!Extensions::disableDefaultLogCaps())
     {


### PR DESCRIPTION
This call to ensure the PLDM response matches the PLDM request for the 'New PEL Available' command was previously missing (since it didn't exist at the time this code was written), causing the code to think it got the correct response when really it was someone else's.

It would then move on to the next PEL before it actually heard back about the current one, causing issues on the host side.

Change-Id: I471d7727a2b8c77a0ffc85c15cef7531898d22d7