### PR TITLE
PEL: Add a new error message for Dump Offload

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6535,8 +6535,22 @@
                 "Words6To9": {}
             },
             "Documentation": {
-                "Description": "Dump has been deleted/offloaded",
-                "Message": "BMC/System/Resource dump has been deleted/offloaded"
+                "Description": "Dump has been deleted",
+                "Message": "BMC/System/Resource dump has been deleted"
+            }
+        },
+        {
+            "Name": "xyz.openbmc_project.Dump.Error.Offload",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x6000",
+            "Severity": "non_error",
+            "SRC": {
+                "ReasonCode": "0x6029",
+                "Words6To9": {}
+            },
+            "Documentation": {
+                "Description": "Dump has been offloaded",
+                "Message": "BMC/System/Resource dump has been offloaded"
             }
         },
         {


### PR DESCRIPTION
We log the same error for Dump Delete and Offload right now. Adding a new error to distinguish between a dump delete and a dump offload.

Change-Id: I1c74906fb170d883447a021c59199baaa4f6dc97