### PR TITLE
PEL: Enable deletion if PEL file is deleted

### DIFF
--- a/extensions/openpower-pels/manager.cpp
+++ b/extensions/openpower-pels/manager.cpp
@@ -308,6 +308,11 @@ void Manager::getLogIDWithHwIsolation(std::vector<uint32_t>& idsWithHwIsoEntry)
 
 bool Manager::isDeleteProhibited(uint32_t obmcLogID)
 {
+    Repository::LogID id{Repository::LogID::Obmc(obmcLogID)};
+    if (!_repo.hasPEL(id))
+    {
+        return false;
+    }
     auto entryPath{std::string(OBJ_ENTRY) + '/' + std::to_string(obmcLogID)};
     auto entry = _pelEntries.find(entryPath);
     if (entry != _pelEntries.end())


### PR DESCRIPTION
- This ensures that PEL objects are deleted if PEL files are deleted, irrespective of links to HWIsolation records.

Tested:
Sample output:
```bash
$ busctl call xyz.openbmc_project.Logging /xyz/openbmc_project/
logging/entry/3 xyz.openbmc_project.Object.Delete Delete
Call failed: The service is temporarily unavailable.

$ peltool -D
```
PEL entry 3 was deleted in above example.
Change-Id: I416fad1d9dc832393b1ba689d582c602e27c79c6
Signed-off-by: Harsh Agarwal <Harsh.Agarwal@ibm.com>

Upstream [Patch](https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/79021).