### PR TITLE
Catch all exceptions when de-serializing

### DIFF
--- a/elog_serialize.cpp
+++ b/elog_serialize.cpp
@@ -131,22 +131,13 @@ bool deserialize(const fs::path& path, Entry& e)
         }
         return false;
     }
-    catch (const cereal::Exception& ex)
+    catch (const std::exception& ex)
     {
-        lg2::error("{EXCEPTION}", "EXCEPTION", ex);
-        fs::remove(path);
-        return false;
-    }
-    catch (const std::length_error& ex)
-    {
-        // Running into: USCiLab/cereal#192
-        // This may be indicating some other issue in the
-        // way vector may have been used inside the logging.
-        // possibly associations ??. But handling it here for
-        // now since we are anyway tossing the log
-        // TODO: openbmc/phosphor-logging#8
-        lg2::error("{EXCEPTION}", "EXCEPTION", ex);
-        fs::remove(path);
+        lg2::error("Failed restoring {PATH}: {EXCEPTION}", "PATH", path,
+                   "EXCEPTION", ex);
+        // Save it for later debug. Just write over any previous ones.
+        auto saveDir = paths::error().parent_path();
+        fs::rename(path, saveDir / "corrupt_error");
         return false;
     }
 }


### PR DESCRIPTION
If an exception were to escape during an event log restore, phosphor-log-manager would just keep continuously crashing and restarting.

To prevent this, just catch all exceptions and move the file that caused it to /var/lib/phosphor-logging/corrupt_error so that it is kept around for debug if desired.  Only the most recent bad file is kept.

Tested:

Instead of crashing, the daemon can now stay up:

```
Mar 19 14:10:06 p10bmc phosphor-log-manager[2953]: Failed restoring /var/lib/phosphor-logging/errors/381: std::bad_alloc

/var/lib/phosphor-logging# ls -l /var/lib/phosphor-logging/corrupt_error
-rw-r--r--    1 root     root           374 Mar 19 13:39 /var/lib/phosphor-logging/corrupt_error
```

Change-Id: Iaa30dff261bbbe048cbca5678f2940cb2a8ed1df