### PR TITLE
Pull in logging fixes from master

### DIFF
--- a/config/config.h.meson
+++ b/config/config.h.meson
@@ -35,7 +35,8 @@ static constexpr auto FIRST_CEREAL_CLASS_VERSION_WITH_UPDATE_TS = "3";
 static constexpr auto FIRST_CEREAL_CLASS_VERSION_WITH_EVENTID = "4";
 static constexpr auto FIRST_CEREAL_CLASS_VERSION_WITH_RESOLUTION = "5";
 static constexpr auto FIRST_CEREAL_CLASS_VERSION_WITH_METADATA_DICT = "6";
-static constexpr size_t CLASS_VERSION = 6;
+static constexpr auto FIRST_CEREAL_CLASS_VERSION_WITH_METADATA_VECTOR = "7";
+static constexpr size_t CLASS_VERSION = 7;
 
 static constexpr bool LG2_COMMIT_DBUS = @lg2_commit_dbus@;
 static constexpr bool LG2_COMMIT_JOURNAL = @lg2_commit_journal@;

--- a/elog_entry.hpp
+++ b/elog_entry.hpp
@@ -77,7 +77,6 @@ class Entry : public EntryIfaces
         updateTimestamp(timestampErr, true);
         message(std::move(msgErr), true);
         additionalData(std::move(additionalDataErr), true);
-        additionalData2(additionalData(), true);
         associations(std::move(objects), true);
         // Store a copy of associations in case we need to recreate
         assocs = associations();

--- a/elog_serialize.cpp
+++ b/elog_serialize.cpp
@@ -31,7 +31,7 @@ namespace logging
 template <class Archive>
 void save(Archive& a, const Entry& e, const std::uint32_t /*version*/)
 {
-    a(e.id(), e.severity(), e.timestamp(), e.message(), e.additionalData2(),
+    a(e.id(), e.severity(), e.timestamp(), e.message(), e.additionalData(),
       e.associations(), e.resolved(), e.version(), e.updateTimestamp(),
       e.eventId(), e.resolution());
 }
@@ -109,7 +109,6 @@ void load(Archive& a, Entry& e, const std::uint32_t version)
     e.timestamp(timestamp, true);
     e.message(message, true);
     e.additionalData(additionalData, true);
-    e.additionalData2(additionalData, true);
     e.sdbusplus::server::xyz::openbmc_project::logging::Entry::resolved(
         resolved, true);
     e.associations(associations, true);

--- a/log_manager.cpp
+++ b/log_manager.cpp
@@ -454,7 +454,7 @@ void Manager::doExtensionLogCreate(const Entry& entry, const FFDCEntries& ffdc)
         try
         {
             create(entry.message(), entry.id(), entry.timestamp(),
-                   entry.severity(), entry.additionalData2(), assocs, ffdc);
+                   entry.severity(), entry.additionalData(), assocs, ffdc);
         }
         catch (const std::exception& e)
         {

--- a/test/serialization_test_properties.cpp
+++ b/test/serialization_test_properties.cpp
@@ -37,7 +37,6 @@ TEST_F(TestSerialization, testProperties)
     EXPECT_EQ(input->timestamp(), output->timestamp());
     EXPECT_EQ(input->message(), output->message());
     EXPECT_EQ(input->additionalData(), output->additionalData());
-    EXPECT_EQ(input->additionalData2(), output->additionalData2());
     EXPECT_EQ(input->resolved(), output->resolved());
     EXPECT_EQ(input->associations(), output->associations());
     EXPECT_EQ(input->version(), output->version());


### PR DESCRIPTION
Has 2 commits:

1. Remove the AdditionalData2 property that was just temporary
2. Go back to storing AdditionalData as a vector in cereal since that is what old code expects.