### PR TITLE
PEL: Add a new error message for Dump Offload

### DIFF
--- a/extensions/openpower-pels/registry/README.md
+++ b/extensions/openpower-pels/registry/README.md
@@ -211,8 +211,9 @@ to use in addition to the ASCII string field to form the symptom ID. All words
 are separated by underscores. If not specified, the code will choose a default
 format, which may depend on the SRC type.
 
-For example: ["SRCWord3", "SRCWord9"] would be: `<ASCII_STRING>_<SRCWord3>_<SRCWord9>`,
-which could look like: `B181320_00000050_49000000`.
+For example: ["SRCWord3", "SRCWord9"] would be:
+`<ASCII_STRING>_<SRCWord3>_<SRCWord9>`, which could look like:
+`B181320_00000050_49000000`.
 
 ```json
 "SymptomIDFields": ["SRCWord3", "SRCWord9"]

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6667,8 +6667,22 @@
                 "Words6To9": {}
             },
             "Documentation": {
-                "Description": "Dump has been deleted/offloaded",
-                "Message": "BMC/System/Resource dump has been deleted/offloaded"
+                "Description": "Dump has been deleted",
+                "Message": "BMC/System/Resource dump has been deleted"
+            }
+        },
+        {
+            "Name": "xyz.openbmc_project.Dump.Error.Offload",
+            "Subsystem": "bmc_firmware",
+            "ComponentID": "0x6000",
+            "Severity": "non_error",
+            "SRC": {
+                "ReasonCode": "0x6029",
+                "Words6To9": {}
+            },
+            "Documentation": {
+                "Description": "Dump has been offloaded",
+                "Message": "BMC/System/Resource dump has been offloaded"
             }
         },
         {


### PR DESCRIPTION
We log the same error for Dump Delete and Offload right now. Adding a new error to distinguish between a dump delete and a dump offload.

Change-Id: I1c74906fb170d883447a021c59199baaa4f6dc97