### PR TITLE
PEL: Fixes for State.Boot.Raw Value updates

### DIFF
--- a/extensions/openpower-pels/data_interface.cpp
+++ b/extensions/openpower-pels/data_interface.cpp
@@ -703,7 +703,8 @@ void DataInterface::createGuardRecord(const std::vector<uint8_t>& binPath,
 #endif
 
 void DataInterface::createProgressSRC(
-    const uint64_t& priSRC, const std::vector<uint8_t>& srcStruct) const
+    const std::vector<uint8_t>& priSRC,
+    const std::vector<uint8_t>& srcStruct) const
 {
     DBusValue variant = std::make_tuple(priSRC, srcStruct);
 
@@ -810,7 +811,8 @@ std::vector<uint32_t> DataInterface::getLogIDWithHwIsolation() const
 
 std::vector<uint8_t> DataInterface::getRawProgressSRC(void) const
 {
-    using RawProgressProperty = std::tuple<uint64_t, std::vector<uint8_t>>;
+    using RawProgressProperty =
+        std::tuple<std::vector<uint8_t>, std::vector<uint8_t>>;
 
     DBusValue value;
     getProperty(service_name::bootRawProgress, object_path::bootRawProgress,

--- a/extensions/openpower-pels/data_interface.hpp
+++ b/extensions/openpower-pels/data_interface.hpp
@@ -473,7 +473,7 @@ class DataInterfaceBase
      * @param[in] srcStruct - Full SRC base structure
      */
     virtual void createProgressSRC(
-        const uint64_t& priSRC,
+        const std::vector<uint8_t>& priSRC,
         const std::vector<uint8_t>& srcStruct) const = 0;
 
     /**
@@ -887,7 +887,7 @@ class DataInterface : public DataInterfaceBase
      * @param[in] srcStruct - Full SRC base structure
      */
     void createProgressSRC(
-        const uint64_t& priSRC,
+        const std::vector<uint8_t>& priSRC,
         const std::vector<uint8_t>& srcStruct) const override;
 
     /**

--- a/extensions/openpower-pels/dbus_types.hpp
+++ b/extensions/openpower-pels/dbus_types.hpp
@@ -19,11 +19,10 @@ using BiosAttributes = std::map<
         std::vector<std::tuple<std::string, std::variant<int64_t, std::string>,
                                std::string>>>>;
 
-using DBusValue =
-    std::variant<std::string, bool, std::vector<uint8_t>,
-                 std::vector<std::string>,
-                 std::vector<std::tuple<std::string, std::string, std::string>>,
-                 std::tuple<uint64_t, std::vector<uint8_t>>, BiosAttributes>;
+using DBusValue = std::variant<
+    std::string, bool, std::vector<uint8_t>, std::vector<std::string>,
+    std::vector<std::tuple<std::string, std::string, std::string>>,
+    std::tuple<std::vector<uint8_t>, std::vector<uint8_t>>, BiosAttributes>;
 using DBusProperty = std::string;
 using DBusInterface = std::string;
 using DBusService = std::string;

--- a/test/openpower-pels/mocks.hpp
+++ b/test/openpower-pels/mocks.hpp
@@ -61,7 +61,7 @@ class MockDataInterface : public DataInterfaceBase
                  const std::string&),
                 (const override));
     MOCK_METHOD(void, createProgressSRC,
-                (const uint64_t&, const std::vector<uint8_t>&),
+                (const std::vector<uint8_t>&, const std::vector<uint8_t>&),
                 (const override));
     MOCK_METHOD(std::vector<uint32_t>, getLogIDWithHwIsolation, (),
                 (const override));


### PR DESCRIPTION
The first entry in the std::tuple of the Value property, which is used to hold the 8 character SRC refcode, changed from a uint64_t to a std::vector<uint8_t>.  Make the necessary updates.

Tested:

Create a PEL with a severity value of 0x51 = critical system termination.  It has the refcode sent to this Value property:

```
$ busctl get-property xyz.openbmc_project.State.Boot.Raw \
/xyz/openbmc_project/state/boot/raw0 \
xyz.openbmc_project.State.Boot.Raw Value
(ayay)
8 49 49 48 48 50 54 48 50
^^ this is the correct 8 byte 11002602 refcode

and the rest is the 72 byte progress SRC:
72 2 9 0 9 0 0 0 188 0 0 0 85 46 45 0
16 0 0 0 0 32 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 49 49 48 48 50 54 48
50 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32 32
```

And now create another PEL, and this progress SRC should be in the hex words:
```
"Reference Code":           "BD8D3601",
"Hex Word 2":               "00000055",
"Hex Word 3":               "2E2D0010",
"Hex Word 4":               "11002602", <-------------------
"Hex Word 5":               "00000000",
"Hex Word 6":               "00000000",
"Hex Word 7":               "00000000",
"Hex Word 8":               "00000000",
"Hex Word 9":               "00000000",
```

Change-Id: I8050eaf3e372b724fa41dc358633d4b3d29fc782