### PR TITLE
1060: PEL: Check for Py_None from parser calls (#108)

### DIFF
--- a/extensions/openpower-pels/src.cpp
+++ b/extensions/openpower-pels/src.cpp
@@ -196,6 +196,12 @@ std::optional<std::string> getPythonJSON(std::vector<std::string>& hexwords,
             {
                 std::unique_ptr<PyObject, decltype(&pyDecRef)> resPtr(
                     pResult, &pyDecRef);
+
+                if (pResult == Py_None)
+                {
+                    return std::nullopt;
+                }
+
                 PyObject* pBytes = PyUnicode_AsEncodedString(pResult, "utf-8",
                                                              "~E~");
                 std::unique_ptr<PyObject, decltype(&pyDecRef)> pyBytePtr(

--- a/extensions/openpower-pels/user_data_json.cpp
+++ b/extensions/openpower-pels/user_data_json.cpp
@@ -331,6 +331,13 @@ std::optional<std::string> getPythonJSON(uint16_t componentID, uint8_t subType,
             {
                 std::unique_ptr<PyObject, decltype(&pyDecRef)> resPtr(
                     pResult, &pyDecRef);
+
+                if (pResult == Py_None)
+                {
+                    // Just return a nullopt so it will hexdump the section
+                    return std::nullopt;
+                }
+
                 PyObject* pBytes = PyUnicode_AsEncodedString(pResult, "utf-8",
                                                              "~E~");
                 std::unique_ptr<PyObject, decltype(&pyDecRef)> pyBytePtr(


### PR DESCRIPTION
#### PEL: Check for Py_None from parser calls (#108)
```
Explicitly check if the UserData or SRC python plugin parsers return a
python None object and just return immediately.  In the UserData case
this results in a hex dump, and in the SRC case it just won't print the
SRC description.

Otherwise, peltool will crash when it tries to extract a string from the
result.

Tested:
peltool no longer crashes.

Change-Id: I2cb87a6071ecc2cbeb9df055f13039ad31fc6384

Signed-off-by: Matt Spinler <spinler@us.ibm.com>
```