### PR TITLE
Add VPD parsing error

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -5395,6 +5395,27 @@
         },
 
         {
+            "Name": "com.ibm.VPD.Error.VPDParseError",
+            "Subsystem": "cec_vpd",
+            "ComponentID": "0x4000",
+
+            "SRC": {
+                "ReasonCode": "0x400D",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "VPD parsing error.",
+                "Message": "An error occurred while parsing VPD file",
+                "Notes": [
+                    "This error occurs when VPD parsing fails for either data or ECC",
+                    "errors for different records for a single EEPROM file. User data",
+                    "will capture the actual reason for parse failure."
+                ]
+            }
+        },
+
+        {
             "Name": "com.ibm.Panel.Error.InputDevPathFailure",
             "Subsystem": "cec_op_panel",
             "ComponentID": "0x5000",


### PR DESCRIPTION
VPD parsing can be failed for both data and ECC errors for different records for a single file. So new generic error is introduced for exception occurred during VPD parsing.