### PR TITLE
Add journal trace for VPD PELs

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -5121,6 +5121,10 @@
                     "EEPROM path. Errno and device path are captured as",
                     "additional data."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5143,6 +5147,10 @@
                     "mandatory records.Inventory path is captured in",
                     "additional data."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5164,6 +5172,10 @@
                     "Inventory path for the failed FRU is captured in additonal",
                     "data."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5194,6 +5206,10 @@
                     "Failed Json path and cause of failure is captured",
                     "in additional data."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5225,6 +5241,10 @@
                     "This error occurs when a default value found on VPD.",
                     "Details regarding failure are captured in additional data."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5254,6 +5274,10 @@
                     "Exceptions details are captured in additonal",
                     "data."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5281,6 +5305,10 @@
                     "If anything gets changed in that combination, then it can't determine",
                     "the appropriate DTB for that system. Need to check HW and IM keywords."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5310,6 +5338,10 @@
                     " or driver issue. Since a hardware or a software issue cannot be",
                     " differentiated, the BMC code will be called out."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5342,6 +5374,10 @@
                     "primary and backup VPD.",
                     "Details regarding the failure are captured in additional data."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5364,6 +5400,10 @@
                     "to be present in the system at the time of power on.",
                     "The inventory path is captured in additional data."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5397,6 +5437,10 @@
                     "should never occur, PE intervention is required to cross check ",
                     "and correct the IM value as needed."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5432,6 +5476,10 @@
                     "decision as to what IM needs to be set to boot the system ",
                     "successfully."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5459,6 +5507,10 @@
                     "can't be categorised in any specific category.",
                     "Cause of failure is captured in additional data."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 
@@ -5480,6 +5532,10 @@
                     "errors for different records for a single EEPROM file. User data",
                     "will capture the actual reason for parse failure."
                 ]
+            },
+
+            "JournalCapture": {
+                "NumLines": 30
             }
         },
 


### PR DESCRIPTION
This commits adds JournalCapture in message_registry for VPD PELs to capture journals at the time of PEL.