### PR TITLE
PEL: FIX: Wait for obmc-recover-pnor before PHAL init

### DIFF
--- a/extensions/openpower-pels/data_interface.cpp
+++ b/extensions/openpower-pels/data_interface.cpp
@@ -1137,8 +1137,7 @@ void DataInterface::subscribeToSystemdSignals()
                         std::string jobUnitName, jobUnitResult;
 
                         msg.read(jobID, jobObjPath, jobUnitName, jobUnitResult);
-                        if ((jobUnitName ==
-                             "openpower-update-bios-attr-table.service") &&
+                        if ((jobUnitName == "obmc-recover-pnor.service") &&
                             (jobUnitResult == "done"))
                         {
 #ifdef PEL_ENABLE_PHAL


### PR DESCRIPTION
Problem:
- It is observed intermittent core dumps from phosphor-log-manager during BMC graceful restart at OSRunning
- Journals show an abort() from dt_expand() in libpdbg immediately after openpower-update-bios-attr-table.service completes

Root cause:
- phosphor-logging subscribed to JobRemoved for openpower-update- bios-attr-table.service and kicked off PHAL init on that signal to avoid loading the default devtree
- In this window, obmc-recover-pnor.service which runs after the openpower-update-bios-attr-table.service may still accessing the devtree, so PHAL attempts to parse a devtree that isn’t ready, leading to libpdbg’s abort() in dt_expand() and a crash

Fix proposed:
- Switch Jobremoved watch from openpower-update-bios-attr-table. service to obmc-recover-pnor.service