### PR TITLE
1060: PEL: FIX: Wait for obmc-recover-pnor before PHAL init (#127)

### DIFF
--- a/extensions/openpower-pels/data_interface.cpp
+++ b/extensions/openpower-pels/data_interface.cpp
@@ -1190,8 +1190,7 @@ void DataInterface::subscribeToSystemdSignals()
                 std::string jobUnitName, jobUnitResult;
 
                 msg.read(jobID, jobObjPath, jobUnitName, jobUnitResult);
-                if ((jobUnitName ==
-                     "openpower-update-bios-attr-table.service") &&
+                if ((jobUnitName == "obmc-recover-pnor.service") &&
                     (jobUnitResult == "done"))
                 {
 #ifdef PEL_ENABLE_PHAL


### PR DESCRIPTION
#### PEL: FIX: Wait for obmc-recover-pnor before PHAL init (#127)
```
Problem:
- It is observed intermittent core dumps from phosphor-log-manager
  during BMC graceful restart at OSRunning
- Journals show an abort() from dt_expand() in libpdbg immediately
  after openpower-update-bios-attr-table.service completes

Root cause:
- phosphor-logging subscribed to JobRemoved for openpower-update-
  bios-attr-table.service and kicked off PHAL init on that signal
  to avoid loading the default devtree
- In this window, obmc-recover-pnor.service which runs after the
  openpower-update-bios-attr-table.service may still accessing the
  devtree, so PHAL attempts to parse a devtree that isn’t ready,
  leading to libpdbg’s abort() in dt_expand() and a crash

Fix proposed:
- Switch Jobremoved watch from openpower-update-bios-attr-table.
  service to obmc-recover-pnor.service

Tested:

Before fix, journal traces showed core dump in phosphor-logging:

```
systemd-coredump[916]: elfutils disabled, parsing ELF objects not
                       supported
systemd-coredump[916]: [🡕] Process 400 (phosphor-log-ma) of user
                        0 dumped core.
systemd[1]: xyz.openbmc_project.Logging.service: Main process
            exited, code=dumped, status=6/ABRT
systemd[1]: xyz.openbmc_project.Logging.service: Failed with
            result 'core-dump'
```

After fix, no core dump observed in traces, service exits cleanly:

```
systemd[1]: Stopped Phosphor LED Group Management Daemon
systemd[1]: xyz.openbmc_project.Logging.service:
            Deactivated successfully.
systemd[1]: Stopped Phosphor Log Manager.
systemd[1]: xyz.openbmc_project.Logging.service:
            Consumed 7.914s CPU time.
```

Change-Id: I0a2115da9ef280bbb722f9c141e780933b452a4b

Signed-off-by: Manish Tiwari <tmanish.in@gmail.com>
```