### PR TITLE
PEL: add journal for phal boot error

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -601,6 +601,18 @@
                 "Notes": [
                     "Debug traces will be captured in AdditionalData section"
                 ]
+            },
+            "JournalCapture": {
+                "Sections": [
+                    {
+                        "SyslogID": "systemd",
+                        "NumLines": 10
+                    },
+                    {
+                        "SyslogID": "openpower-proc-control",
+                        "NumLines": 30
+                    }
+                ]
             }
         },
 


### PR DESCRIPTION
Add journal traces entries for phal boot error

https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/88832

Change-Id: I7b9e441d8d7b388d813c3a0056c320de26aa61a4