### PR TITLE
PEL: Removing Backplane CCIN value from data

### DIFF
--- a/extensions/openpower-pels/data_interface.cpp
+++ b/extensions/openpower-pels/data_interface.cpp
@@ -58,8 +58,6 @@ namespace object_path
 {
 constexpr auto objectMapper = "/xyz/openbmc_project/object_mapper";
 constexpr auto systemInv = "/xyz/openbmc_project/inventory/system";
-constexpr auto motherBoardInv =
-    "/xyz/openbmc_project/inventory/system/chassis/motherboard";
 constexpr auto baseInv = "/xyz/openbmc_project/inventory";
 constexpr auto bmcState = "/xyz/openbmc_project/state/bmc0";
 constexpr auto chassisState = "/xyz/openbmc_project/state/chassis0";
@@ -394,34 +392,6 @@ std::string DataInterface::getMachineSerialNumber() const
     }
 
     return sn;
-}
-
-std::string DataInterface::getMotherboardCCIN() const
-{
-    std::string ccin;
-
-    try
-    {
-        auto service =
-            getService(object_path::motherBoardInv, interface::viniRecordVPD);
-        if (!service.empty())
-        {
-            DBusValue value;
-            getProperty(service, object_path::motherBoardInv,
-                        interface::viniRecordVPD, "CC", value);
-
-            auto cc = std::get<std::vector<uint8_t>>(value);
-            ccin = std::string{cc.begin(), cc.end()};
-        }
-    }
-    catch (const std::exception& e)
-    {
-        lg2::warning("Failed reading Motherboard CCIN property from "
-                     "interface: {IFACE} exception: {ERROR}",
-                     "IFACE", interface::viniRecordVPD, "ERROR", e);
-    }
-
-    return ccin;
 }
 
 std::vector<uint8_t> DataInterface::getSystemIMKeyword() const

--- a/extensions/openpower-pels/data_interface.cpp
+++ b/extensions/openpower-pels/data_interface.cpp
@@ -290,6 +290,17 @@ DBusPathList DataInterface::getPaths(const DBusInterfaceList& interfaces) const
     return paths;
 }
 
+DBusSubTree DataInterface::getSubTree(const DBusInterfaceList& interfaces) const
+{
+    auto method = _bus.new_method_call(service_name::objectMapper,
+                                       object_path::objectMapper,
+                                       interface::objectMapper, "GetSubTree");
+    method.append(std::string{"/"}, 0, interfaces);
+    auto reply = _bus.call(method, dbusTimeout);
+
+    return reply.unpack<DBusSubTree>();
+}
+
 DBusService DataInterface::getService(const std::string& objectPath,
                                       const std::string& interface) const
 {
@@ -415,20 +426,30 @@ std::string DataInterface::getMotherboardCCIN() const
 
 std::vector<uint8_t> DataInterface::getSystemIMKeyword() const
 {
-    std::vector<uint8_t> systemIM;
+    static std::vector<uint8_t> systemIM;
+
+    if (!systemIM.empty())
+    {
+        return systemIM;
+    }
 
     try
     {
-        auto service =
-            getService(object_path::motherBoardInv, interface::vsbpRecordVPD);
-        if (!service.empty())
-        {
-            DBusValue value;
-            getProperty(service, object_path::motherBoardInv,
-                        interface::vsbpRecordVPD, "IM", value);
+        auto subtree = getSubTree({interface::vsbpRecordVPD});
 
-            systemIM = std::get<std::vector<uint8_t>>(value);
+        if (subtree.empty())
+        {
+            lg2::warning("No VSBP VPD interface found");
+            return systemIM;
         }
+
+        DBusValue imValue;
+        const auto& path = subtree.begin()->first;
+        const auto& interfaceMap = subtree.begin()->second;
+        const auto& service = interfaceMap.begin()->first;
+        getProperty(service, path, interface::vsbpRecordVPD, "IM", imValue);
+
+        systemIM = std::get<std::vector<uint8_t>>(imValue);
     }
     catch (const std::exception& e)
     {
@@ -628,17 +649,8 @@ void DataInterface::setCriticalAssociation(const std::string& objectPath) const
 
 std::vector<std::string> DataInterface::getSystemNames() const
 {
-    DBusSubTree subtree;
-    DBusValue names;
+    auto subtree = getSubTree({interface::compatible});
 
-    auto method = _bus.new_method_call(service_name::objectMapper,
-                                       object_path::objectMapper,
-                                       interface::objectMapper, "GetSubTree");
-    method.append(std::string{"/"}, 0,
-                  std::vector<std::string>{interface::compatible});
-    auto reply = _bus.call(method, dbusTimeout);
-
-    reply.read(subtree);
     if (subtree.empty())
     {
         throw std::runtime_error("Compatible interface not on D-Bus");
@@ -651,6 +663,8 @@ std::vector<std::string> DataInterface::getSystemNames() const
         {
             continue;
         }
+
+        DBusValue names;
 
         getProperty(iface->first, path, interface::compatible, "Names", names);
 

--- a/extensions/openpower-pels/data_interface.hpp
+++ b/extensions/openpower-pels/data_interface.hpp
@@ -321,13 +321,6 @@ class DataInterfaceBase
     }
 
     /**
-     * @brief Returns the motherboard CCIN
-     *
-     * @return std::string The motherboard CCIN
-     */
-    virtual std::string getMotherboardCCIN() const = 0;
-
-    /**
      * @brief Returns the system IM
      *
      * @return std::string The system IM
@@ -761,13 +754,6 @@ class DataInterface : public DataInterfaceBase
      * @return string - The machine serial number
      */
     std::string getMachineSerialNumber() const override;
-
-    /**
-     * @brief Returns the motherboard CCIN
-     *
-     * @return std::string The motherboard CCIN
-     */
-    std::string getMotherboardCCIN() const override;
 
     /**
      * @brief Returns the system IM

--- a/extensions/openpower-pels/data_interface.hpp
+++ b/extensions/openpower-pels/data_interface.hpp
@@ -988,6 +988,15 @@ class DataInterface : public DataInterfaceBase
     DBusPathList getPaths(const DBusInterfaceList& interfaces) const;
 
     /**
+     * @brief Wrapper for the mapper's GetSubTree
+     *
+     * @param[in] interfaces - The desired interfaces
+     *
+     * @return The D-Bus paths.
+     */
+    DBusSubTree getSubTree(const DBusInterfaceList& interfaces) const;
+
+    /**
      * @brief The interfacesAdded callback used on the inventory to
      *        find the D-Bus object that has the motherboard interface.
      *        When the motherboard is found, it then adds a PropertyWatcher

--- a/extensions/openpower-pels/src.cpp
+++ b/extensions/openpower-pels/src.cpp
@@ -38,8 +38,6 @@ namespace pv = openpower::pels::pel_values;
 namespace rg = openpower::pels::message;
 using namespace std::string_literals;
 
-constexpr size_t ccinSize = 4;
-
 #ifdef PELTOOL
 using orderedJSON = nlohmann::ordered_json;
 
@@ -346,7 +344,6 @@ SRC::SRC(const message::Entry& regEntry, const AdditionalData& additionalData,
     setProgressCode(dataIface);
     setBMCFormat();
     setBMCPosition();
-    setMotherboardCCIN(dataIface);
 
     if (regEntry.src.checkstopFlag)
     {
@@ -424,29 +421,6 @@ void SRC::setUserDefinedHexWords(const message::Entry& regEntry,
             addDebugData(msg);
         }
     }
-}
-
-void SRC::setMotherboardCCIN(const DataInterfaceBase& dataIface)
-{
-    uint32_t ccin = 0;
-    auto ccinString = dataIface.getMotherboardCCIN();
-
-    try
-    {
-        if (ccinString.size() == ccinSize)
-        {
-            ccin = std::stoi(ccinString, 0, 16);
-        }
-    }
-    catch (const std::exception& e)
-    {
-        lg2::warning("Could not convert motherboard CCIN {CCIN} to a number",
-                     "CCIN", ccinString);
-        return;
-    }
-
-    // Set the first 2 bytes
-    _hexData[1] |= ccin << 16;
 }
 
 void SRC::validate()
@@ -736,16 +710,6 @@ std::optional<std::string> SRC::getJSON(message::Registry& registry,
 
     if (isBMCSRC())
     {
-        std::string ccinString;
-        uint32_t ccin = _hexData[1] >> 16;
-
-        if (ccin)
-        {
-            ccinString = getNumberString("%04X", ccin);
-        }
-        // The PEL spec calls it a backplane, so call it that here.
-        jsonInsert(ps, "Backplane CCIN", ccinString, 1);
-
         jsonInsert(ps, "Terminate FW Error",
                    pv::boolString.at(
                        _hexData[3] &

--- a/extensions/openpower-pels/src.hpp
+++ b/extensions/openpower-pels/src.hpp
@@ -400,13 +400,6 @@ class SRC : public Section
     }
 
     /**
-     * @brief Sets the motherboard CCIN hex word field
-     *
-     * @param[in] dataIface - The DataInterface object
-     */
-    void setMotherboardCCIN(const DataInterfaceBase& dataIface);
-
-    /**
      * @brief Sets the progress code hex word field
      *
      * @param[in] dataIface - The DataInterface object

--- a/test/openpower-pels/mocks.hpp
+++ b/test/openpower-pels/mocks.hpp
@@ -34,7 +34,6 @@ class MockDataInterface : public DataInterfaceBase
     MOCK_METHOD(std::string, getBMCState, (), (const override));
     MOCK_METHOD(std::string, getChassisState, (), (const override));
     MOCK_METHOD(std::string, getHostState, (), (const override));
-    MOCK_METHOD(std::string, getMotherboardCCIN, (), (const override));
     MOCK_METHOD(void, getHWCalloutFields,
                 (const std::string&, std::string&, std::string&, std::string&),
                 (const override));

--- a/test/openpower-pels/src_test.cpp
+++ b/test/openpower-pels/src_test.cpp
@@ -206,8 +206,6 @@ TEST_F(SRCTest, CreateTestNoCallouts)
     AdditionalData ad{adData};
     NiceMock<MockDataInterface> dataIface;
 
-    EXPECT_CALL(dataIface, getMotherboardCCIN).WillOnce(Return("ABCD"));
-
     SRC src{entry, ad, dataIface};
 
     EXPECT_TRUE(src.valid());
@@ -223,7 +221,6 @@ TEST_F(SRCTest, CreateTestNoCallouts)
     EXPECT_EQ(hexwords[2 - 2] & 0x00F00000, 0);    // Partition boot type
     EXPECT_EQ(hexwords[2 - 2] & 0x000000FF, 0x55); // SRC format
     EXPECT_EQ(hexwords[3 - 2] & 0x000000FF, 0x10); // BMC position
-    EXPECT_EQ(hexwords[3 - 2] & 0xFFFF0000, 0xABCD0000); // Motherboard CCIN
 
     // Validate more fields here as the code starts filling them in.
 
@@ -253,48 +250,6 @@ TEST_F(SRCTest, CreateTestNoCallouts)
     EXPECT_TRUE(newSRC.valid());
     EXPECT_EQ(newSRC.asciiString(), src.asciiString());
     EXPECT_FALSE(newSRC.callouts());
-}
-
-// Test when the CCIN string isn't a 4 character number
-TEST_F(SRCTest, BadCCINTest)
-{
-    message::Entry entry;
-    entry.src.type = 0xBD;
-    entry.src.reasonCode = 0xABCD;
-    entry.subsystem = 0x42;
-
-    std::map<std::string, std::string> adData{};
-    AdditionalData ad{adData};
-    NiceMock<MockDataInterface> dataIface;
-
-    // First it isn't a number, then it is too long,
-    // then it is empty.
-    EXPECT_CALL(dataIface, getMotherboardCCIN)
-        .WillOnce(Return("X"))
-        .WillOnce(Return("12345"))
-        .WillOnce(Return(""));
-
-    // The CCIN in the first half should still be 0 each time.
-    {
-        SRC src{entry, ad, dataIface};
-        EXPECT_TRUE(src.valid());
-        const auto& hexwords = src.hexwordData();
-        EXPECT_EQ(hexwords[3 - 2] & 0xFFFF0000, 0x00000000);
-    }
-
-    {
-        SRC src{entry, ad, dataIface};
-        EXPECT_TRUE(src.valid());
-        const auto& hexwords = src.hexwordData();
-        EXPECT_EQ(hexwords[3 - 2] & 0xFFFF0000, 0x00000000);
-    }
-
-    {
-        SRC src{entry, ad, dataIface};
-        EXPECT_TRUE(src.valid());
-        const auto& hexwords = src.hexwordData();
-        EXPECT_EQ(hexwords[3 - 2] & 0xFFFF0000, 0x00000000);
-    }
 }
 
 // Test the getErrorDetails function
@@ -1552,8 +1507,6 @@ TEST_F(SRCTest, TestPELSubsystem)
     std::map<std::string, std::string> adData{{"PEL_SUBSYSTEM", "0x20"}};
     AdditionalData ad{adData};
     NiceMock<MockDataInterface> dataIface;
-
-    EXPECT_CALL(dataIface, getMotherboardCCIN).WillOnce(Return("ABCD"));
 
     SRC src{entry, ad, dataIface};
 


### PR DESCRIPTION
There are two gerrit changes in this PR:
- https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/86583
- https://gerrit.openbmc.org/c/openbmc/phosphor-logging/+/88871  