### PR TITLE
Rename RBMC option and restore synced event logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,9 +489,8 @@ Resolve or clear the corresponding entry to allow the system to boot.
 ## Encoding the BMC position in the entry ID
 
 On redundant BMC systems where multiple BMCs can be creating event logs, the
-'use-bmc-pos-in-id' meson option will trigger the encoding of the BMC position
-into the upper byte of the event log ID so that all event logs will have unique
-IDs.
+'redundant-bmc' meson option will trigger the encoding of the BMC position into
+the upper byte of the event log ID so that all event logs will have unique IDs.
 
 The BMC position is read from the file /run/openbmc/bmc_position.
 

--- a/config/config.h.meson
+++ b/config/config.h.meson
@@ -41,6 +41,6 @@ static constexpr size_t CLASS_VERSION = 7;
 static constexpr bool LG2_COMMIT_DBUS = @lg2_commit_dbus@;
 static constexpr bool LG2_COMMIT_JOURNAL = @lg2_commit_journal@;
 
-static constexpr bool USE_BMC_POS_IN_ID = @use_bmc_pos_in_id@;
+static constexpr bool REDUNDANT_BMC = @redundant_bmc@;
 
 // vim: ft=cpp

--- a/config/meson.build
+++ b/config/meson.build
@@ -14,8 +14,8 @@ conf_data.set(
     lg2_commit_strategy == 'journal' or lg2_commit_strategy == 'both' ? 'true' : 'false',
 )
 
-use_bmc_pos_in_id = get_option('use-bmc-pos-in-id')
-conf_data.set10('use_bmc_pos_in_id', use_bmc_pos_in_id)
+redundant_bmc = get_option('redundant-bmc')
+conf_data.set10('redundant_bmc', redundant_bmc)
 
 cxx = meson.get_compiler('cpp')
 if cxx.has_header('poll.h')

--- a/extensions/openpower-pels/log_id.cpp
+++ b/extensions/openpower-pels/log_id.cpp
@@ -81,7 +81,7 @@ namespace detail
 uint32_t addLogIDPrefix(uint32_t id)
 {
     uint32_t pos = 0;
-    if (USE_BMC_POS_IN_ID || IS_UNIT_TEST)
+    if (REDUNDANT_BMC || IS_UNIT_TEST)
     {
         pos = (position::bmcPosition & 0xF) << 24;
     }

--- a/extensions/openpower-pels/manager.cpp
+++ b/extensions/openpower-pels/manager.cpp
@@ -84,7 +84,7 @@ void Manager::create(const std::string& message, uint32_t obmcLogID,
     AdditionalData ad{additionalData};
 
     // Extract the latest BMC position value
-    if (USE_BMC_POS_IN_ID || IS_UNIT_TEST)
+    if (REDUNDANT_BMC || IS_UNIT_TEST)
     {
         position::extractBMCPositionFromLogID(obmcLogID);
     }

--- a/extensions/openpower-pels/pel.cpp
+++ b/extensions/openpower-pels/pel.cpp
@@ -941,7 +941,7 @@ std::unique_ptr<UserData> makeSysInfoUserDataSection(
     addBMCFWVersionIDToJSON(json, dataIface);
     addIMKeyword(json, dataIface);
     addStatesToJSON(json, dataIface);
-    if (USE_BMC_POS_IN_ID || IS_UNIT_TEST)
+    if (REDUNDANT_BMC || IS_UNIT_TEST)
     {
         addBMCRedundancyFieldsToJSON(json, dataIface);
     }

--- a/log_manager.cpp
+++ b/log_manager.cpp
@@ -226,7 +226,7 @@ auto Manager::createEntry(std::string errMsg, Entry::Level errLvl,
         }
     }
 
-    if constexpr (USE_BMC_POS_IN_ID)
+    if constexpr (REDUNDANT_BMC)
     {
         if (!bmcPosMgr->isPositionValid())
         {
@@ -719,7 +719,7 @@ void Manager::restore()
         }
     }
 
-    if constexpr (!USE_BMC_POS_IN_ID)
+    if constexpr (!REDUNDANT_BMC)
     {
         if (!entries.empty())
         {

--- a/log_manager.cpp
+++ b/log_manager.cpp
@@ -58,6 +58,21 @@ inline auto getLevel(const std::string& errMsg)
     return reqLevel;
 }
 
+Manager::~Manager()
+{
+    if constexpr (REDUNDANT_BMC)
+    {
+        if (errDirInotifyFD != -1)
+        {
+            if (errDirWatcherWD != -1)
+            {
+                inotify_rm_watch(errDirInotifyFD, errDirWatcherWD);
+            }
+            close(errDirInotifyFD);
+        }
+    }
+}
+
 int Manager::getRealErrSize()
 {
     return realErrors.size();
@@ -758,6 +773,143 @@ auto Manager::create(const std::string& message, Entry::Level severity,
                      const FFDCEntries& ffdc) -> sdbusplus::message::object_path
 {
     return createEntry(message, severity, additionalData, ffdc);
+}
+
+void Manager::setupErrorFileWatch()
+{
+    auto errDir = paths::error();
+
+    // In the redundant BMC sync flow, files are written to a temporary path
+    // first and moved into place only after the write completes. Using
+    // IN_MOVED_TO ensures we react only when the finalized file appears in the
+    // target directory.
+    uint32_t mask = IN_MOVED_TO;
+
+    if (!util::setupInotifyWatch(errDir, mask, errDirInotifyFD,
+                                 errDirWatcherWD))
+    {
+        abort();
+    }
+
+    errorFileWatchEventSource = std::make_unique<sdeventplus::source::IO>(
+        event, errDirInotifyFD, EPOLLIN,
+        std::bind_front(&Manager::errorFileChanged, this));
+}
+
+void Manager::errorFileChanged(sdeventplus::source::IO&, int, uint32_t revents)
+{
+    if (!(revents & EPOLLIN))
+    {
+        return;
+    }
+
+    // As per inotify(7), sizeof(struct inotify_event) + NAME_MAX + 1 is
+    // sufficient for one worst-case event. Keep a larger buffer so one read
+    // can drain multiple queued events. this size allows up to 240
+    // worst-case events in a single read.
+    std::array<uint8_t, 272 * 240> buf{};
+    const auto bytesRead = read(errDirInotifyFD, buf.data(), buf.size());
+    if (bytesRead < 0)
+    {
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+            return;
+        }
+
+        lg2::error("read(inotify errors) failed errno {ERRNO}", "ERRNO", errno);
+        return;
+    }
+
+    const auto totalBytes = static_cast<size_t>(bytesRead);
+    size_t offset = 0;
+
+    while (offset < totalBytes)
+    {
+        auto* ev = reinterpret_cast<inotify_event*>(&buf[offset]);
+
+        if (ev->len)
+        {
+            try
+            {
+                const auto idNum =
+                    static_cast<uint32_t>(std::stoul(ev->name, nullptr, 10));
+
+                if (ev->mask & IN_MOVED_TO)
+                {
+                    if (!entries.contains(idNum))
+                    {
+                        if (!restoreFromDisk(idNum))
+                        {
+                            lg2::error("Failed to restore entry {ID} from disk",
+                                       "ID", idNum);
+                        }
+                    }
+                }
+            }
+            catch (const std::exception& e)
+            {
+                lg2::error(
+                    "Could not parse error entry ID from filename {NAME}",
+                    "NAME", ev->name);
+            }
+        }
+
+        offset += offsetof(inotify_event, name) + ev->len;
+    }
+}
+
+bool Manager::restoreFromDisk(uint32_t id)
+{
+    const fs::path path = paths::error() / std::to_string(id);
+
+    std::error_code ec;
+    if (!fs::is_regular_file(path, ec))
+    {
+        return false;
+    }
+
+    const std::string objPath =
+        std::string(OBJ_ENTRY) + "/" + std::to_string(id);
+
+    auto entry = std::make_unique<Entry>(busLog, objPath, id, *this);
+
+    if (!deserialize(path, *entry))
+    {
+        lg2::error("Failed to deserialize entry {ID} from {PATH}", "ID", id,
+                   "PATH", path);
+        return false;
+    }
+
+    if (entry->id() != id)
+    {
+        lg2::error(
+            "Sanity check failed while restoring entry EXPECTED_ID={EXPECTED_ID} "
+            "RESTORED_ID={RESTORED_ID}",
+            "EXPECTED_ID", id, "RESTORED_ID", entry->id());
+        return false;
+    }
+
+    entry->path(path, true);
+
+    auto [it, inserted] = entries.emplace(id, std::move(entry));
+
+    if (it->second->severity() >= Entry::sevLowerLimit)
+    {
+        infoErrors.push_back(id);
+    }
+    else
+    {
+        realErrors.push_back(id);
+    }
+
+    it->second->emit_object_added();
+
+    if (bmcPosMgr->idContainsCurrentPosition(id))
+    {
+        entryId = std::max(entryId, id);
+    }
+
+    return true;
 }
 
 } // namespace internal

--- a/log_manager.hpp
+++ b/log_manager.hpp
@@ -9,6 +9,7 @@
 
 #include <phosphor-logging/log.hpp>
 #include <sdbusplus/bus.hpp>
+#include <sdeventplus/source/io.hpp>
 #include <xyz/openbmc_project/Collection/DeleteAll/server.hpp>
 #include <xyz/openbmc_project/Logging/Create/server.hpp>
 #include <xyz/openbmc_project/Logging/Entry/server.hpp>
@@ -67,7 +68,7 @@ class Manager : public details::ServerObject<details::ManagerIface>
     Manager& operator=(const Manager&) = delete;
     Manager(Manager&&) = delete;
     Manager& operator=(Manager&&) = delete;
-    virtual ~Manager() = default;
+    virtual ~Manager();
 
     /** @brief Constructor to put object onto bus at a dbus path.
      *  @param[in] bus - Bus to attach to.
@@ -75,7 +76,8 @@ class Manager : public details::ServerObject<details::ManagerIface>
      */
     Manager(sdbusplus::bus_t& bus, const char* objPath) :
         details::ServerObject<details::ManagerIface>(bus, objPath), busLog(bus),
-        entryId(0), fwVersion(readFWVersion())
+        entryId(0), fwVersion(readFWVersion()),
+        event(sdeventplus::Event::get_default())
     {
         if constexpr (REDUNDANT_BMC)
         {
@@ -228,6 +230,14 @@ class Manager : public details::ServerObject<details::ManagerIface>
      */
     void checkAndRemoveBlockingError(uint32_t entryId);
 
+    /**
+     * @brief Sets up an inotify watch on the error entry directory.
+     *
+     * Watches for interested events which indicate that a new error entry
+     * file has has been synced in a redundant BMC system.
+     */
+    void setupErrorFileWatch();
+
     /** @brief Persistent map of Entry dbus objects and their ID */
     std::map<uint32_t, std::unique_ptr<Entry>> entries;
 
@@ -303,6 +313,24 @@ class Manager : public details::ServerObject<details::ManagerIface>
      */
     void checkAndQuiesceHost();
 
+    /** @brief Restore a single error entry from disk into the entries map and
+     *         D-Bus
+     *
+     * @param[in] id - The entry ID to restore
+     * @return true if the entry was successfully restored, false otherwise
+     */
+    bool restoreFromDisk(uint32_t id);
+
+    /**
+     * @brief Handles inotify events for the error entry directory.
+     *
+     * @param[in] io - The event source object.
+     * @param[in] fd - File descriptor for the inotify instance.
+     * @param[in] revents - Event flags returned by epoll.
+     */
+    void errorFileChanged(sdeventplus::source::IO& io, int fd,
+                          uint32_t revents);
+
     /** @brief Persistent sdbusplus DBus bus connection. */
     sdbusplus::bus_t& busLog;
 
@@ -327,6 +355,28 @@ class Manager : public details::ServerObject<details::ManagerIface>
 
     /** @brief Encodes the BMC position in the entryId when enabled */
     std::unique_ptr<BMCPosMgr> bmcPosMgr;
+
+    /**
+     * @brief Event source used to monitor error entry directory changes.
+     */
+    std::unique_ptr<sdeventplus::source::IO> errorFileWatchEventSource;
+
+    /**
+     * @brief Reference to the sd-event wrapper used to register event sources.
+     */
+    sdeventplus::Event event;
+
+    /**
+     * @brief File descriptor returned by inotify_init1() for the error entry
+     * watcher.
+     */
+    int errDirInotifyFD = -1;
+
+    /**
+     * @brief Watch descriptor returned by inotify_add_watch() for the error
+     * entry directory.
+     */
+    int errDirWatcherWD = -1;
 };
 
 } // namespace internal

--- a/log_manager.hpp
+++ b/log_manager.hpp
@@ -77,7 +77,7 @@ class Manager : public details::ServerObject<details::ManagerIface>
         details::ServerObject<details::ManagerIface>(bus, objPath), busLog(bus),
         entryId(0), fwVersion(readFWVersion())
     {
-        if constexpr (USE_BMC_POS_IN_ID)
+        if constexpr (REDUNDANT_BMC)
         {
             bmcPosMgr = std::make_unique<BMCPosMgr>();
         }

--- a/log_manager_main.cpp
+++ b/log_manager_main.cpp
@@ -37,6 +37,12 @@ int main(int argc, char* argv[])
     // Create a directory to persist errors.
     std::filesystem::create_directories(phosphor::logging::paths::error());
 
+    if constexpr (REDUNDANT_BMC)
+    {
+        // Start watching for newly synced error files.
+        iMgr.setupErrorFileWatch();
+    }
+
     // Recreate error d-bus objects from persisted errors.
     iMgr.restore();
 

--- a/meson.options
+++ b/meson.options
@@ -58,8 +58,8 @@ option(
 )
 
 option(
-    'use-bmc-pos-in-id',
+    'redundant-bmc',
     type: 'boolean',
     value: true,
-    description: 'If the BMC position should be encoded into the event log ID',
+    description: 'Enable support for redundant BMC systems',
 )

--- a/util.cpp
+++ b/util.cpp
@@ -197,6 +197,32 @@ void journalSync()
     return;
 }
 
+bool setupInotifyWatch(const std::string& path, uint32_t mask, int& inotifyFD,
+                       int& watcherWD)
+{
+    inotifyFD = inotify_init1(IN_NONBLOCK);
+    if (inotifyFD == -1)
+    {
+        lg2::error("inotify_init1 failed for {PATH} with errno {ERRNO}", "PATH",
+                   path, "ERRNO", errno);
+        return false;
+    }
+
+    watcherWD = inotify_add_watch(inotifyFD, path.c_str(), mask);
+    if (watcherWD == -1)
+    {
+        lg2::error("inotify_add_watch failed for {PATH} with errno {ERRNO}",
+                   "PATH", path, "ERRNO", errno);
+
+        // close the inotify file descriptor if we failed to add the watch
+        close(inotifyFD);
+        inotifyFD = -1;
+        return false;
+    }
+
+    return true;
+}
+
 namespace additional_data
 {
 auto parse(const std::vector<std::string>& data)

--- a/util.hpp
+++ b/util.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <fstream>
 #include <map>
 #include <optional>
@@ -24,6 +25,19 @@ std::optional<std::string> getOSReleaseValue(const std::string& key);
  *          "journalctl --sync".
  */
 void journalSync();
+
+/**
+ * @brief Set up an inotify watch on a directory
+ *
+ * @param[in] path - The directory path to watch
+ * @param[in] mask - The inotify event mask
+ * @param[out] inotifyFD - The file descriptor returned by inotify_init1
+ * @param[out] watcherWD - The watch descriptor returned by inotify_add_watch
+ *
+ * @return true if setup was successful, false otherwise
+ */
+bool setupInotifyWatch(const std::string& path, uint32_t mask, int& inotifyFD,
+                       int& watcherWD);
 
 namespace additional_data
 {


### PR DESCRIPTION
This PR renames the existing `use-bmc-pos-in-id` Meson option to `redundant-bmc` because the option now gates broader redundant-BMC behavior, not only BMC position encoding.

It also adds support to restore synced event log entries from disk so redundant BMC systems can rebuild the in-memory/D-Bus state when synced logs are received.

Tested:
- Verified `config.h` generates `REDUNDANT_BMC = 1` for RBMC machines
- Verified `config.h` generates `REDUNDANT_BMC = 0` for non-RBMC machines
- Added/updated RBMC sync test coverage