### PR TITLE
1210: support for PEL sync notifications

### DIFF
--- a/bmc_pos_mgr.cpp
+++ b/bmc_pos_mgr.cpp
@@ -5,6 +5,7 @@
 
 #include <phosphor-logging/lg2.hpp>
 
+#include <chrono>
 #include <fstream>
 
 namespace phosphor::logging
@@ -15,6 +16,12 @@ constexpr uint32_t entryIdValueMask = 0x00FFFFFF;
 
 uint32_t BMCPosMgr::processEntryId(uint32_t id) const
 {
+    // If position is invalid, generate a time-based ID
+    if (!isPositionValid())
+    {
+        return getTimeBasedEntryId();
+    }
+
     setPrefixInEntryId(id);
 
     // Roll it over at 0x00FFFFFF
@@ -86,6 +93,18 @@ void BMCPosMgr::readBMCPosition()
 bool BMCPosMgr::idContainsCurrentPosition(uint32_t id) const
 {
     return (id >> 24) == bmcPosition;
+}
+
+uint32_t BMCPosMgr::getTimeBasedEntryId() const
+{
+    using namespace std::chrono;
+
+    // Use 3 bytes of the nanosecond count since the epoch.
+    uint32_t id =
+        duration_cast<nanoseconds>(system_clock::now().time_since_epoch())
+            .count();
+
+    return (id & entryIdValueMask) | (static_cast<uint32_t>(noPosition) << 24);
 }
 
 } // namespace phosphor::logging

--- a/bmc_pos_mgr.hpp
+++ b/bmc_pos_mgr.hpp
@@ -92,6 +92,16 @@ class BMCPosMgr
     void checkEntryIdRollover(uint32_t& id) const;
 
     /**
+     * @brief Generates a time-based entry ID when position is not available.
+     *
+     * Uses nanoseconds since epoch to create a unique ID across
+     * redundant BMC systems when the position file doesn't exist.
+     *
+     * @return A unique time-based entry ID with 0xFF position marker
+     */
+    uint32_t getTimeBasedEntryId() const;
+
+    /**
      * @brief The BMC position.
      *
      * 0xFF if the position can't be obtained.

--- a/elog_entry.cpp
+++ b/elog_entry.cpp
@@ -129,5 +129,45 @@ void Entry::closeFD(int fd, sdeventplus::source::EventBase& /*source*/)
     fdCloseEventSource.reset();
 }
 
+Entry& Entry::operator=(const Entry& source)
+{
+    if (resolved() != source.resolved())
+    {
+        resolved(source.resolved());
+    }
+
+    if (resolution() != source.resolution())
+    {
+        resolution(source.resolution());
+    }
+
+    if (eventId() != source.eventId())
+    {
+        eventId(source.eventId());
+    }
+
+    if (severity() != source.severity())
+    {
+        severity(source.severity());
+    }
+
+    if (message() != source.message())
+    {
+        message(source.message());
+    }
+
+    if (additionalData() != source.additionalData())
+    {
+        additionalData(source.additionalData());
+    }
+
+    if (serviceProviderNotify() != source.serviceProviderNotify())
+    {
+        serviceProviderNotify(source.serviceProviderNotify());
+    }
+
+    return *this;
+}
+
 } // namespace logging
 } // namespace phosphor

--- a/elog_entry.hpp
+++ b/elog_entry.hpp
@@ -43,7 +43,6 @@ class Entry : public EntryIfaces
   public:
     Entry() = delete;
     Entry(const Entry&) = delete;
-    Entry& operator=(const Entry&) = delete;
     Entry(Entry&&) = delete;
     Entry& operator=(Entry&&) = delete;
     virtual ~Entry() = default;
@@ -106,6 +105,17 @@ class Entry : public EntryIfaces
     {
         id(entryId, true);
     };
+
+    /**
+     * @brief Assignment operator to update entry properties.
+     *
+     * Updates properties from source entry, emitting D-Bus signals for changes.
+     * Used to refresh in-memory entries from persisted data.
+     *
+     * @param[in] source - The source entry
+     * @return Reference to this entry
+     */
+    Entry& operator=(const Entry& source);
 
     /** @brief Set resolution status of the error.
      *  @param[in] value - boolean indicating resolution

--- a/extensions.cpp
+++ b/extensions.cpp
@@ -35,6 +35,12 @@ LogIDsWithHwIsolationFunctions& Extensions::getLogIDWithHwIsolationFunctions()
     return logIDWithHwIsolationFunctions;
 }
 
+ExtensionLogAssociations& Extensions::getExtensionLogAssociationFunctions()
+{
+    static ExtensionLogAssociations extensionLogAssociationFunctions{};
+    return extensionLogAssociationFunctions;
+}
+
 Extensions::DefaultErrorCaps& Extensions::getDefaultErrorCaps()
 {
     static DefaultErrorCaps defaultErrorCaps = DefaultErrorCaps::enable;

--- a/extensions.hpp
+++ b/extensions.hpp
@@ -64,10 +64,20 @@ using LogIDWithHwIsolationFunction =
 using LogIDsWithHwIsolationFunctions =
     std::vector<LogIDWithHwIsolationFunction>;
 
+/**
+ * @brief Function type used to handle associations for a restored
+ *        log entry in an extension.
+ * @param[in] uint32_t - OpenBMC log ID of the entry
+ * @param[in] const std::string - D-Bus object path of the entry
+ */
+using ExtensionLogAssociation =
+    std::function<void(uint32_t, const std::string&)>;
+
 using StartupFunctions = std::vector<StartupFunction>;
 using CreateFunctions = std::vector<CreateFunction>;
 using DeleteFunctions = std::vector<DeleteFunction>;
 using DeleteProhibitedFunctions = std::vector<DeleteProhibitedFunction>;
+using ExtensionLogAssociations = std::vector<ExtensionLogAssociation>;
 
 /**
  * @brief Register an extension hook function
@@ -186,6 +196,20 @@ class Extensions
     }
 
     /**
+     * @brief Constructor to register a log entry association function
+     *
+     * Functions registered with this constructor are called after a
+     * log entry is restored from disk, allowing extensions to
+     * establish any required associations for that entry.
+     *
+     * @param[in] func - The function to register
+     */
+    explicit Extensions(ExtensionLogAssociation func)
+    {
+        getExtensionLogAssociationFunctions().push_back(func);
+    }
+
+    /**
      * @brief Constructor to disable event log capping
      *
      * This constructor should only be called by the
@@ -235,6 +259,12 @@ class Extensions
      * @return DefaultErrorCaps - the DefaultErrorCaps value
      */
     static DefaultErrorCaps& getDefaultErrorCaps();
+
+    /**
+     * @brief Returns the ExtensionLogAssociation functions
+     * @return ExtensionLogAssociations - the ExtensionLogAssociation functions
+     */
+    static ExtensionLogAssociations& getExtensionLogAssociationFunctions();
 
     /**
      * @brief Say if the default log capping policy should be disabled

--- a/extensions/openpower-pels/entry_points.cpp
+++ b/extensions/openpower-pels/entry_points.cpp
@@ -94,5 +94,13 @@ void getLogIDWithHwIsolation(std::vector<uint32_t>& logIDs)
 
 REGISTER_EXTENSION_FUNCTION(getLogIDWithHwIsolation)
 
+void pelEntryRestored([[maybe_unused]] uint32_t obmcId,
+                      [[maybe_unused]] const std::string& objectPath)
+{
+    // TODO: Call API to link the restored entry with its corresponding PEL.
+}
+
+REGISTER_EXTENSION_FUNCTION(pelEntryRestored)
+
 } // namespace pels
 } // namespace openpower

--- a/extensions/openpower-pels/entry_points.cpp
+++ b/extensions/openpower-pels/entry_points.cpp
@@ -94,10 +94,10 @@ void getLogIDWithHwIsolation(std::vector<uint32_t>& logIDs)
 
 REGISTER_EXTENSION_FUNCTION(getLogIDWithHwIsolation)
 
-void pelEntryRestored([[maybe_unused]] uint32_t obmcId,
+void pelEntryRestored(uint32_t obmcId,
                       [[maybe_unused]] const std::string& objectPath)
 {
-    // TODO: Call API to link the restored entry with its corresponding PEL.
+    manager->linkPELToEventLog(obmcId);
 }
 
 REGISTER_EXTENSION_FUNCTION(pelEntryRestored)

--- a/extensions/openpower-pels/log_id.cpp
+++ b/extensions/openpower-pels/log_id.cpp
@@ -153,6 +153,13 @@ uint32_t generatePELID()
         return detail::getTimeBasedLogID();
     }
 
+    // In redundant BMC systems, if position is invalid, use time-based ID
+    if ((REDUNDANT_BMC || IS_UNIT_TEST) &&
+        position::bmcPosition == invalidPELIDPosition)
+    {
+        return detail::getTimeBasedLogID();
+    }
+
     return detail::addLogIDPrefix(id);
 }
 

--- a/extensions/openpower-pels/manager.cpp
+++ b/extensions/openpower-pels/manager.cpp
@@ -585,7 +585,7 @@ void Manager::setupPELFileWatch()
 {
     auto pelDir = _repo.repoPath();
 
-    uint32_t mask = IN_DELETE;
+    uint32_t mask = IN_DELETE | IN_MOVED_TO;
     if (!phosphor::logging::util::setupInotifyWatch(
             pelDir, mask, _pelDirWatchFD, _pelDirWatcherWD))
     {
@@ -638,6 +638,13 @@ void Manager::pelFileChanged(sdeventplus::source::IO& /*io*/, int /*fd*/,
                 {
                     handlePELDelete(name);
                 }
+                else if (ev->mask & IN_MOVED_TO)
+                {
+                    if constexpr (REDUNDANT_BMC)
+                    {
+                        handlePELMovedTo(name);
+                    }
+                }
             }
             catch (const std::exception& e)
             {
@@ -666,6 +673,74 @@ void Manager::handlePELDelete(const std::string& filename)
             _logManager.erase(removedLogID->obmcID.id);
         }
     }
+}
+
+void Manager::handlePELMovedTo(const std::string& filename)
+{
+    auto pos = filename.find_first_of('_');
+    if (pos == std::string::npos)
+    {
+        lg2::warning("Filename does not contain '_' separator: {FILE}", "FILE",
+                     filename);
+        return;
+    }
+
+    auto path = _repo.repoPath() / filename;
+
+    try
+    {
+        restorePELFromDisk(path, filename);
+    }
+    catch (const std::exception& e)
+    {
+        lg2::error("Failed to process PEL file {FILE}: {ERROR}", "FILE",
+                   filename, "ERROR", e);
+    }
+}
+
+void Manager::restorePELFromDisk(const std::filesystem::path& path,
+                                 const std::string& filename)
+{
+    auto logId = _repo.importPELFromFile(path);
+    if (!logId)
+    {
+        lg2::warning("Failed to import PEL from file: {FILE}", "FILE",
+                     filename);
+        return;
+    }
+
+    linkPELToEventLog(logId->obmcID.id);
+}
+
+void Manager::linkPELToEventLog(uint32_t obmcLogID)
+{
+    // This function links a new PEL with its event log entry by creating
+    // a D-Bus PELEntry interface object. It's called when:
+    // 1. A new PEL file is restored
+    // 2. An event log entry is restored
+    //
+    // If either the event log or PEL is missing, we return early and wait
+    // for the other piece to arrive (at which point this will be called again).
+
+    // Verify event log entry exists
+    if (!_logManager.entries.contains(obmcLogID))
+    {
+        lg2::debug("Skipping link, event log missing. OBMC_ID={OBMC_ID}",
+                   "OBMC_ID", obmcLogID);
+        return;
+    }
+
+    // Complete the pending PEL link
+    if (!_repo.completePELLink(obmcLogID))
+    {
+        lg2::debug("Skipping link, PEL missing. OBMC_ID={OBMC_ID}", "OBMC_ID",
+                   obmcLogID);
+        return;
+    }
+
+    setEntryPath(obmcLogID);
+    setServiceProviderNotifyFlag(obmcLogID);
+    createPELEntry(obmcLogID, false);
 }
 
 std::tuple<uint32_t, uint32_t> Manager::createPELWithFFDCFiles(

--- a/extensions/openpower-pels/manager.cpp
+++ b/extensions/openpower-pels/manager.cpp
@@ -26,6 +26,7 @@
 #include "pel_entry.hpp"
 #include "service_indicators.hpp"
 #include "severity.hpp"
+#include "util.hpp"
 
 #include <sys/inotify.h>
 #include <unistd.h>
@@ -65,13 +66,13 @@ constexpr uint32_t bmcFansCompID = 0x2800;
 
 Manager::~Manager()
 {
-    if (_pelFileDeleteFD != -1)
+    if (_pelDirWatchFD != -1)
     {
-        if (_pelFileDeleteWatchFD != -1)
+        if (_pelDirWatcherWD != -1)
         {
-            inotify_rm_watch(_pelFileDeleteFD, _pelFileDeleteWatchFD);
+            inotify_rm_watch(_pelDirWatchFD, _pelDirWatcherWD);
         }
-        close(_pelFileDeleteFD);
+        close(_pelDirWatchFD);
     }
 }
 
@@ -580,33 +581,23 @@ void Manager::pruneRepo(sdeventplus::source::EventBase& /*source*/)
     _repoPrunerEventSource.reset();
 }
 
-void Manager::setupPELDeleteWatch()
+void Manager::setupPELFileWatch()
 {
-    _pelFileDeleteFD = inotify_init1(IN_NONBLOCK);
-    if (-1 == _pelFileDeleteFD)
+    auto pelDir = _repo.repoPath();
+
+    uint32_t mask = IN_DELETE;
+    if (!phosphor::logging::util::setupInotifyWatch(
+            pelDir, mask, _pelDirWatchFD, _pelDirWatcherWD))
     {
-        auto e = errno;
-        lg2::error("inotify_init1 failed with errno {ERRNO}", "ERRNO", e);
         abort();
     }
 
-    _pelFileDeleteWatchFD = inotify_add_watch(
-        _pelFileDeleteFD, _repo.repoPath().c_str(), IN_DELETE);
-    if (-1 == _pelFileDeleteWatchFD)
-    {
-        auto e = errno;
-        lg2::error("inotify_add_watch failed with errno {ERRNO}", "ERRNO", e);
-        abort();
-    }
-
-    _pelFileDeleteEventSource = std::make_unique<sdeventplus::source::IO>(
-        _event, _pelFileDeleteFD, EPOLLIN,
-        std::bind(std::mem_fn(&Manager::pelFileDeleted), this,
-                  std::placeholders::_1, std::placeholders::_2,
-                  std::placeholders::_3));
+    _pelDirWatchEventSource = std::make_unique<sdeventplus::source::IO>(
+        _event, _pelDirWatchFD, EPOLLIN,
+        std::bind_front(&Manager::pelFileChanged, this));
 }
 
-void Manager::pelFileDeleted(sdeventplus::source::IO& /*io*/, int /*fd*/,
+void Manager::pelFileChanged(sdeventplus::source::IO& /*io*/, int /*fd*/,
                              uint32_t revents)
 {
     if (!(revents & EPOLLIN))
@@ -614,55 +605,66 @@ void Manager::pelFileDeleted(sdeventplus::source::IO& /*io*/, int /*fd*/,
         return;
     }
 
-    // An event for 1 PEL uses 48B. When all PELs are deleted at once,
-    // as many events as there is room for can be handled in one callback.
-    // A size of 2000 will allow 41 to be processed, with additional
-    // callbacks being needed to process the remaining ones.
-    std::array<uint8_t, 2000> data{};
-    auto bytesRead = read(_pelFileDeleteFD, data.data(), data.size());
+    // As per inotify(7), sizeof(struct inotify_event) + NAME_MAX + 1 is
+    // sufficient for one worst-case event. Keep a larger buffer so one read
+    // can drain multiple queued events. This size allows up to 240
+    // worst-case events in a single read.
+    std::array<uint8_t, 272 * 240> buf{};
+    auto bytesRead = read(_pelDirWatchFD, buf.data(), buf.size());
     if (bytesRead < 0)
     {
-        auto e = errno;
-        lg2::error("Failed reading data from inotify event, errno = {ERRNO}",
-                   "ERRNO", e);
-        abort();
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+            return;
+        }
+
+        lg2::error("read data(inotify PEL) failed errno {ERRNO}", "ERRNO",
+                   errno);
+        return;
     }
 
-    auto offset = 0;
-    while (offset < bytesRead)
+    size_t offset = 0;
+    while (offset < static_cast<size_t>(bytesRead))
     {
-        auto event = reinterpret_cast<inotify_event*>(&data[offset]);
-        if (event->mask & IN_DELETE)
+        auto* ev = reinterpret_cast<inotify_event*>(&buf[offset]);
+
+        if (ev->len)
         {
-            std::string filename{event->name};
-
-            // Get the PEL ID from the filename and tell the
-            // repo it's been removed, and then delete the BMC
-            // event log if it's there.
-            auto pos = filename.find_first_of('_');
-            if (pos != std::string::npos)
+            try
             {
-                try
-                {
-                    auto idString = filename.substr(pos + 1);
-                    auto pelID = std::stoul(idString, nullptr, 16);
+                std::string name{ev->name};
 
-                    Repository::LogID id{Repository::LogID::Pel(pelID)};
-                    auto removedLogID = _repo.remove(id);
-                    if (removedLogID)
-                    {
-                        _logManager.erase(removedLogID->obmcID.id);
-                    }
-                }
-                catch (const std::exception& e)
+                if (ev->mask & IN_DELETE)
                 {
-                    lg2::info("Could not find PEL ID from its filename {NAME}",
-                              "NAME", filename);
+                    handlePELDelete(name);
                 }
+            }
+            catch (const std::exception& e)
+            {
+                lg2::error(
+                    "Failed to process PEL event: NAME={NAME}, ERR={ERR}",
+                    "NAME", ev->name, "ERR", e);
             }
         }
 
-        offset += offsetof(inotify_event, name) + event->len;
+        offset += offsetof(inotify_event, name) + ev->len;
+    }
+}
+
+void Manager::handlePELDelete(const std::string& filename)
+{
+    auto pos = filename.find_first_of('_');
+    if (pos != std::string::npos)
+    {
+        auto idString = filename.substr(pos + 1);
+        auto pelID = static_cast<uint32_t>(std::stoul(idString, nullptr, 16));
+
+        Repository::LogID id{Repository::LogID::Pel(pelID)};
+        auto removedLogID = _repo.remove(id);
+        if (removedLogID)
+        {
+            _logManager.erase(removedLogID->obmcID.id);
+        }
     }
 }
 

--- a/extensions/openpower-pels/manager.cpp
+++ b/extensions/openpower-pels/manager.cpp
@@ -689,7 +689,21 @@ void Manager::handlePELMovedTo(const std::string& filename)
 
     try
     {
-        restorePELFromDisk(path, filename);
+        // Extract PEL ID from filename
+        auto idString = filename.substr(pos + 1);
+        auto pelID = static_cast<uint32_t>(std::stoul(idString, nullptr, 16));
+
+        Repository::LogID id{Repository::LogID::Pel(pelID)};
+        auto existingLogId = _repo.getLogID(id);
+
+        if (existingLogId)
+        {
+            refreshPELFromDisk(*existingLogId, path, filename);
+        }
+        else
+        {
+            restorePELFromDisk(path, filename);
+        }
     }
     catch (const std::exception& e)
     {
@@ -741,6 +755,48 @@ void Manager::linkPELToEventLog(uint32_t obmcLogID)
     setEntryPath(obmcLogID);
     setServiceProviderNotifyFlag(obmcLogID);
     createPELEntry(obmcLogID, false);
+}
+
+void Manager::refreshPELFromDisk(const Repository::LogID& existingLogId,
+                                 const std::filesystem::path& path,
+                                 const std::string& filename)
+{
+    if (!_repo.updatePELFromFile(existingLogId, path))
+    {
+        lg2::warning("Failed to update PEL from file: {FILE}", "FILE",
+                     filename);
+        return;
+    }
+
+    // Update D-Bus properties if PELEntry exists
+    auto entryPath =
+        std::string(OBJ_ENTRY) + "/" + std::to_string(existingLogId.obmcID.id);
+    if (_pelEntries.contains(entryPath))
+    {
+        updatePELEntryProperties(existingLogId.obmcID.id);
+    }
+}
+
+void Manager::updatePELEntryProperties(uint32_t obmcLogID)
+{
+    const auto entryPath =
+        std::string{OBJ_ENTRY} + "/" + std::to_string(obmcLogID);
+
+    if (const auto it = _pelEntries.find(entryPath); it != _pelEntries.end())
+    {
+        const Repository::LogID id{Repository::LogID::Obmc{obmcLogID}};
+
+        if (const auto attributes = _repo.getPELAttributes(id); attributes)
+        {
+            using PELEntryIface =
+                sdbusplus::server::org::open_power::logging::pel::Entry;
+
+            const auto newAckValue =
+                attributes->get().hmcState == TransmissionState::acked;
+
+            it->second->PELEntryIface::managementSystemAck(newAckValue, false);
+        }
+    }
 }
 
 std::tuple<uint32_t, uint32_t> Manager::createPELWithFFDCFiles(

--- a/extensions/openpower-pels/manager.hpp
+++ b/extensions/openpower-pels/manager.hpp
@@ -296,6 +296,17 @@ class Manager : public PELInterface
      */
     static std::string sanitizeFieldForDBus(std::string field);
 
+    /**
+     * @brief Attempts to link a PEL with its corresponding OpenBMC event log
+     *        entry.
+     *
+     * Creates the PELEntry interface only when both the OpenBMC event
+     * log entry and the corresponding PEL are available.
+     *
+     * @param[in] obmcLogID - OpenBMC event log ID associated with the PEL.
+     */
+    void linkPELToEventLog(uint32_t obmcLogID);
+
   private:
     /**
      * @brief Adds a received raw PEL to the PEL repository
@@ -529,6 +540,28 @@ class Manager : public PELInterface
      * @param[in] filename - Name of the deleted PEL file.
      */
     void handlePELDelete(const std::string& filename);
+
+    /**
+     * @brief Handles a PEL file appearing in the pel directory.
+     *
+     * In a redundant BMC system, this is triggered when a PEL file becomes
+     * available at its final location after synchronization.
+     *
+     * @param[in] filename - Name of the moved PEL file.
+     */
+    void handlePELMovedTo(const std::string& filename);
+
+    /**
+     * @brief Restores a PEL from disk.
+     *
+     * Imports the PEL into the repository and attempts to link it with the
+     * corresponding event log entry.
+     *
+     * @param[in] path - Path to the PEL file
+     * @param[in] filename - Name of the PEL file
+     */
+    void restorePELFromDisk(const std::filesystem::path& path,
+                            const std::string& filename);
 
     /**
      * @brief Reference to phosphor-logging's Manager class

--- a/extensions/openpower-pels/manager.hpp
+++ b/extensions/openpower-pels/manager.hpp
@@ -564,6 +564,30 @@ class Manager : public PELInterface
                             const std::string& filename);
 
     /**
+     * @brief Handles an existing PEL being updated from a file.
+     *
+     * Updates the repository and refreshes D-Bus properties if PELEntry exists.
+     *
+     * @param[in] existingLogId - The LogID of the existing PEL
+     * @param[in] path - Path to the updated PEL file
+     * @param[in] filename - Name of the PEL file (for logging)
+     */
+    void refreshPELFromDisk(const Repository::LogID& existingLogId,
+                            const std::filesystem::path& path,
+                            const std::string& filename);
+
+    /**
+     * @brief Updates the D-Bus ManagementSystemAck properties from the current
+     *        in-memory PELAttributes.
+     *
+     * Used when a PEL is modified on the active BMC and synchronized
+     * to the passive BMC via rsync.
+     *
+     * @param[in] obmcLogID - The OpenBMC log ID of the entry to update
+     */
+    void updatePELEntryProperties(uint32_t obmcLogID);
+
+    /**
      * @brief Reference to phosphor-logging's Manager class
      */
     phosphor::logging::internal::Manager& _logManager;

--- a/extensions/openpower-pels/manager.hpp
+++ b/extensions/openpower-pels/manager.hpp
@@ -65,7 +65,7 @@ class Manager : public PELInterface
             createPELEntry(entry.first, true);
         }
 
-        setupPELDeleteWatch();
+        setupPELFileWatch();
 
         _dataIface->subscribeToFruPresent(
             "Manager",
@@ -389,19 +389,23 @@ class Manager : public PELInterface
     void pruneRepo(sdeventplus::source::EventBase& source);
 
     /**
-     * @brief Sets up an inotify watch to watch for deleted PEL
-     *        files.  Calls pelFileDeleted() when that occurs.
+     * @brief Sets up an inotify watch on the PEL directory.
+     *
+     * Watches for interested events which indicate that a PEL file has been
+     * created, updated, or deleted
      */
-    void setupPELDeleteWatch();
+    void setupPELFileWatch();
 
     /**
-     * @brief Called when the inotify watch put on the repository directory
-     *        detects a PEL file was deleted.
+     * @brief Handles inotify events for the PEL repository directory.
      *
-     * Will tell the Repository class about the deleted PEL, and then tell
-     * the log manager class to delete the corresponding OpenBMC event log.
+     * Dispatches the event to the appropriate handler based on the event type
+     *
+     * @param[in] io - The event source object.
+     * @param[in] fd - File descriptor for the inotify instance.
+     * @param[in] revents - Event flags returned by epoll.
      */
-    void pelFileDeleted(sdeventplus::source::IO& io, int fd, uint32_t revents);
+    void pelFileChanged(sdeventplus::source::IO& io, int fd, uint32_t revents);
 
     /**
      * @brief Check if the input PEL should cause a quiesce of the system
@@ -517,6 +521,16 @@ class Manager : public PELInterface
     void hardwarePresent(const std::string& locationCode);
 
     /**
+     * @brief Handles deletion of a PEL file.
+     *
+     * Removes the corresponding PEL from the repository and deletes the
+     * associated OpenBMC event log entry if present.
+     *
+     * @param[in] filename - Name of the deleted PEL file.
+     */
+    void handlePELDelete(const std::string& filename);
+
+    /**
      * @brief Reference to phosphor-logging's Manager class
      */
     phosphor::logging::internal::Manager& _logManager;
@@ -588,18 +602,18 @@ class Manager : public PELInterface
     /**
      * @brief The even source for watching for deleted PEL files.
      */
-    std::unique_ptr<sdeventplus::source::IO> _pelFileDeleteEventSource;
+    std::unique_ptr<sdeventplus::source::IO> _pelDirWatchEventSource;
 
     /**
-     * @brief The file descriptor returned by inotify_init1() used
-     *        for watching for deleted PEL files.
+     * @brief File descriptor returned by inotify_init1() for the PEL watcher.
      */
-    int _pelFileDeleteFD = -1;
+    int _pelDirWatchFD = -1;
 
     /**
-     * @brief The file descriptor returned by inotify_add_watch().
+     * @brief Watch descriptor returned by inotify_add_watch() for the PEL
+     * directory.
      */
-    int _pelFileDeleteWatchFD = -1;
+    int _pelDirWatcherWD = -1;
 };
 
 } // namespace pels

--- a/extensions/openpower-pels/repository.cpp
+++ b/extensions/openpower-pels/repository.cpp
@@ -787,5 +787,95 @@ void Repository::archivePEL(const PEL& pel)
     }
 }
 
+std::optional<std::tuple<Repository::LogID, Repository::PELAttributes,
+                         std::shared_ptr<PEL>>>
+    Repository::parsePELFile(const std::filesystem::path& path)
+{
+    namespace fs = std::filesystem;
+
+    if (!fs::is_regular_file(path))
+    {
+        lg2::error("PEL file missing or not regular: {FILE}", "FILE",
+                   path.string());
+        return std::nullopt;
+    }
+
+    std::ifstream file{path, std::ios::in | std::ios::binary};
+    if (!file.good())
+    {
+        lg2::error("Failed to open PEL file: {FILE}", "FILE", path.string());
+        return std::nullopt;
+    }
+
+    std::vector<uint8_t> data{std::istreambuf_iterator<char>(file),
+                              std::istreambuf_iterator<char>()};
+
+    auto pel = std::make_shared<PEL>(data);
+    if (!pel->valid())
+    {
+        lg2::error("Invalid PEL file in parsePELFile: {FILE}", "FILE", path);
+        return std::nullopt;
+    }
+
+    LogID key{LogID::Pel{pel->id()}, LogID::Obmc{pel->obmcLogID()}};
+
+    PELAttributes attrs{
+        path,
+        getFileDiskSize(path),
+        pel->privateHeader().creatorID(),
+        pel->userHeader().subsystem(),
+        pel->userHeader().severity(),
+        pel->userHeader().actionFlags(),
+        pel->hostTransmissionState(),
+        pel->hmcTransmissionState(),
+        pel->plid(),
+        pel->getDeconfigFlag(),
+        pel->getGuardFlag(),
+        getMillisecondsSinceEpoch(pel->privateHeader().createTimestamp()),
+    };
+
+    return std::make_tuple(key, attrs, pel);
+}
+
+std::optional<Repository::LogID> Repository::importPELFromFile(
+    const std::filesystem::path& path)
+{
+    auto result = parsePELFile(path);
+
+    if (!result)
+    {
+        return std::nullopt;
+    }
+
+    auto& [key, attrs, pel] = *result;
+
+    // Store in _pendingPELs map instead of immediately adding to
+    // _pelAttributes. Will be added to repository index when both PEL and event
+    // log exist.
+    _pendingPELs.emplace(key.obmcID.id, std::move(*result));
+
+    return key;
+}
+
+bool Repository::completePELLink(uint32_t obmcLogID)
+{
+    auto it = _pendingPELs.find(obmcLogID);
+    if (it == _pendingPELs.end())
+    {
+        return false;
+    }
+
+    auto& [key, attrs, pel] = it->second;
+
+    _pelAttributes.emplace(key, attrs);
+    updateRepoStats(attrs, true);
+    processAddCallbacks(*pel);
+
+    // Remove from pending list
+    _pendingPELs.erase(it);
+
+    return true;
+}
+
 } // namespace pels
 } // namespace openpower

--- a/extensions/openpower-pels/repository.cpp
+++ b/extensions/openpower-pels/repository.cpp
@@ -877,5 +877,26 @@ bool Repository::completePELLink(uint32_t obmcLogID)
     return true;
 }
 
+bool Repository::updatePELFromFile(const LogID& existingKey,
+                                   const std::filesystem::path& path)
+{
+    auto it = _pelAttributes.find(existingKey);
+    if (it == _pelAttributes.end())
+    {
+        return false;
+    }
+
+    auto result = parsePELFile(path);
+    if (!result)
+    {
+        return false;
+    }
+
+    auto& [key, attrs, pel] = *result;
+
+    it->second = attrs;
+    return true;
+}
+
 } // namespace pels
 } // namespace openpower

--- a/extensions/openpower-pels/repository.hpp
+++ b/extensions/openpower-pels/repository.hpp
@@ -489,6 +489,19 @@ class Repository
      */
     bool completePELLink(uint32_t obmcLogID);
 
+    /**
+     * @brief Updates an existing PEL's attributes from a file on disk.
+     *
+     * Reads the PEL file and updates the in-memory attributes for an
+     * existing PEL entry.
+     *
+     * @param[in] existingKey - The LogID key of the existing PEL
+     * @param[in] path - The path to the updated PEL file
+     * @return bool - True if successful, false otherwise
+     */
+    bool updatePELFromFile(const LogID& existingKey,
+                           const std::filesystem::path& path);
+
   private:
     /**
      * @brief Finds an entry in the _pelAttributes map.

--- a/extensions/openpower-pels/repository.hpp
+++ b/extensions/openpower-pels/repository.hpp
@@ -469,6 +469,26 @@ class Repository
      */
     bool updatePEL(const std::filesystem::path& path, PELUpdateFunc updateFunc);
 
+    /**
+     * @brief Imports a PEL from disk into the repository.
+     *
+     * Reads and validates the PEL file, builds its repository data, and
+     * stores it in the repository.
+     *
+     * @param[in] path - Path to the PEL file
+     * @return std::optional<LogID> containing the PEL LogID on success,
+     *         or std::nullopt on failure
+     */
+    std::optional<LogID> importPELFromFile(const std::filesystem::path& path);
+
+    /**
+     * @brief Completes PEL link by moving from pending to repository index.
+     *
+     * @param[in] obmcLogID - The OpenBMC log ID
+     * @return true if pending PEL found and linked, false otherwise
+     */
+    bool completePELLink(uint32_t obmcLogID);
+
   private:
     /**
      * @brief Finds an entry in the _pelAttributes map.
@@ -569,6 +589,21 @@ class Repository
                     const IsPELTypeFunc& isPELType,
                     const std::vector<uint32_t>& idsWithHwIsoEntry,
                     std::vector<uint32_t>& removedBMCLogIDs);
+
+    /**
+     * @brief Reads and validates a PEL file from disk.
+     *
+     * Extracts the LogID, repository attributes, and PEL object from the
+     * file contents without adding them to the repository.
+     *
+     * @param[in] path - Path to the PEL file
+     * @return std::optional<std::tuple<LogID, PELAttributes,
+     *         std::shared_ptr<PEL>>> containing the parsed data on success,
+     *         or std::nullopt on failure
+     */
+    std::optional<std::tuple<LogID, PELAttributes, std::shared_ptr<PEL>>>
+        parsePELFile(const std::filesystem::path& path);
+
     /**
      * @brief The filesystem path to the PEL logs.
      */
@@ -620,6 +655,14 @@ class Repository
      * @brief The size of archive folder.
      */
     uint64_t _archiveSize = 0;
+
+    /**
+     * @brief Pending PELs awaiting event log link before adding to repository.
+     *        Map key: OpenBMC log ID
+     *        Map value: tuple<LogID, PELAttributes, shared_ptr<PEL>>
+     */
+    std::map<uint32_t, std::tuple<LogID, PELAttributes, std::shared_ptr<PEL>>>
+        _pendingPELs;
 };
 
 } // namespace pels

--- a/log_manager.cpp
+++ b/log_manager.cpp
@@ -836,7 +836,15 @@ void Manager::errorFileChanged(sdeventplus::source::IO&, int, uint32_t revents)
 
                 if (ev->mask & IN_MOVED_TO)
                 {
-                    if (!entries.contains(idNum))
+                    if (entries.contains(idNum))
+                    {
+                        if (!refreshFromDisk(idNum))
+                        {
+                            lg2::error("Failed to refresh entry {ID} from disk",
+                                       "ID", idNum);
+                        }
+                    }
+                    else
                     {
                         if (!restoreFromDisk(idNum))
                         {
@@ -908,6 +916,47 @@ bool Manager::restoreFromDisk(uint32_t id)
     {
         entryId = std::max(entryId, id);
     }
+
+    return true;
+}
+
+bool Manager::refreshFromDisk(uint32_t id)
+{
+    auto it = entries.find(id);
+    if (it == entries.end() || !it->second)
+    {
+        lg2::error("Unknown refreshed entry ID {ID}", "ID", id);
+        return false;
+    }
+
+    const fs::path path = paths::error() / std::to_string(id);
+
+    std::error_code ec;
+    if (!fs::is_regular_file(path, ec))
+    {
+        return false;
+    }
+
+    // Max uint32_t value
+    const uint32_t tempId = 0xFFFFFFFF;
+    auto tempEntry = std::make_unique<Entry>(
+        busLog, std::string(OBJ_ENTRY) + "/" + std::to_string(tempId), tempId,
+        *this);
+
+    // Read the persisted entry data from disk into the temporary entry
+    if (!deserialize(path, *tempEntry))
+    {
+        lg2::error("Failed to deserialize entry {ID} from {PATH}", "ID", id,
+                   "PATH", path);
+        return false;
+    }
+
+    // Assign properties from the deserialized temp entry using assignment
+    // operator, will only update properties that differ
+    auto& existingEntry = it->second;
+    *existingEntry = *tempEntry;
+
+    existingEntry->path(path, true);
 
     return true;
 }

--- a/log_manager.cpp
+++ b/log_manager.cpp
@@ -783,7 +783,10 @@ void Manager::setupErrorFileWatch()
     // first and moved into place only after the write completes. Using
     // IN_MOVED_TO ensures we react only when the finalized file appears in the
     // target directory.
-    uint32_t mask = IN_MOVED_TO;
+    //
+    // IN_DELETE handles synced file removals so the corresponding in-memory
+    // event log entry is also removed.
+    uint32_t mask = IN_MOVED_TO | IN_DELETE;
 
     if (!util::setupInotifyWatch(errDir, mask, errDirInotifyFD,
                                  errDirWatcherWD))
@@ -851,6 +854,13 @@ void Manager::errorFileChanged(sdeventplus::source::IO&, int, uint32_t revents)
                             lg2::error("Failed to restore entry {ID} from disk",
                                        "ID", idNum);
                         }
+                    }
+                }
+                else if (ev->mask & IN_DELETE)
+                {
+                    if (entries.contains(idNum))
+                    {
+                        erase(idNum);
                     }
                 }
             }

--- a/log_manager.cpp
+++ b/log_manager.cpp
@@ -922,6 +922,20 @@ bool Manager::restoreFromDisk(uint32_t id)
 
     it->second->emit_object_added();
 
+    for (auto& func : Extensions::getExtensionLogAssociationFunctions())
+    {
+        try
+        {
+            func(id, objPath);
+        }
+        catch (const std::exception& e)
+        {
+            lg2::error(
+                "An extension's PEL entry link function threw an exception: {ERROR}",
+                "ERROR", e);
+        }
+    }
+
     if (bmcPosMgr->idContainsCurrentPosition(id))
     {
         entryId = std::max(entryId, id);

--- a/log_manager.hpp
+++ b/log_manager.hpp
@@ -321,6 +321,14 @@ class Manager : public details::ServerObject<details::ManagerIface>
      */
     bool restoreFromDisk(uint32_t id);
 
+    /** @brief Refresh a single error entry from disk
+     *
+     * @param[in] id - The entry ID to refresh
+     * @return true if the entry was successfully refreshed,
+     *         false otherwise
+     */
+    bool refreshFromDisk(uint32_t id);
+
     /**
      * @brief Handles inotify events for the error entry directory.
      *

--- a/test/bmc_pos_mgr_test.cpp
+++ b/test/bmc_pos_mgr_test.cpp
@@ -86,16 +86,13 @@ TEST(BMCPosMgrTest, ProcessEntryId)
         // No position change no rollover
         {0, 1, 1},
         {1, 1, 0x01000001},
-        {0xFF, 0xFF000000, 0xFF000000},
 
         // Change positions
         {0, 0x01000001, 0x00000001},
         {1, 0x00000001, 0x01000001},
-        {0xFF, 0x00000001, 0xFF000001},
         {0, 0xFF000001, 0x00000001},
 
         // Rollovers
-        {0xFF, 0xFFFFFFFF, 0xFF000000},
         {0, 0x00FFFFFF, 0x00000000},
         {1, 0x01FFFFFF, 0x01000000},
         {1, 0xFFFFFFFF, 0x01000000}};
@@ -107,6 +104,20 @@ TEST(BMCPosMgrTest, ProcessEntryId)
 
         EXPECT_EQ(mgr.processEntryId(test.id), test.expected);
     }
+}
+
+TEST(BMCPosMgrTest, ProcessEntryIdWhenPositionInvalid)
+{
+    PosFile file{0};
+    BMCPosMgr mgr{file.path};
+
+    file.remove();
+    mgr.readBMCPosition();
+
+    auto id = mgr.processEntryId(0x00000001);
+
+    EXPECT_EQ(id & 0xFF000000, 0xFF000000);
+    EXPECT_NE(id & 0x00FFFFFF, 0x00000001);
 }
 
 TEST(BMCPosMgrTest, IdContainsCurrentPosition)

--- a/test/log_manager_rbmc_sync_test.cpp
+++ b/test/log_manager_rbmc_sync_test.cpp
@@ -1,0 +1,165 @@
+#include "elog_entry.hpp"
+#include "elog_serialize.hpp"
+#include "log_manager.hpp"
+#include "paths.hpp"
+
+#include <unistd.h>
+
+#include <sdbusplus/test/sdbus_mock.hpp>
+#include <sdeventplus/event.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+#include <gtest/gtest.h>
+
+namespace phosphor::logging::test
+{
+namespace fs = std::filesystem;
+
+class LogManagerRedundantBMCSyncTest : public ::testing::Test
+{
+  protected:
+    void SetUp() override
+    {
+        sd_event_default(&sdEvent);
+        bus = sdbusplus::get_mocked_new(&sdbusMock);
+        manager = std::make_unique<internal::Manager>(bus, OBJ_INTERNAL);
+
+        // paths::error() is shared across test binaries, so do not delete the
+        // whole directory here. Just make sure it exists and clean up only the
+        // file used by this test.
+        fs::create_directories(paths::error());
+
+        const auto* testInfo =
+            ::testing::UnitTest::GetInstance()->current_test_info();
+
+        tempEntryDir = fs::temp_directory_path() /
+                       ("elog_sync_temp_" + std::to_string(::getpid()) + "_" +
+                        std::string(testInfo->name()));
+        fs::remove_all(tempEntryDir);
+        fs::create_directories(tempEntryDir);
+
+        entryId = 77;
+        repoEntryPath = paths::error() / std::to_string(entryId);
+
+        fs::remove(repoEntryPath);
+    }
+
+    void TearDown() override
+    {
+        fs::remove(repoEntryPath);
+        fs::remove_all(tempEntryDir);
+
+        manager.reset();
+
+        if (sdEvent != nullptr)
+        {
+            sd_event_unref(sdEvent);
+            sdEvent = nullptr;
+        }
+    }
+
+    fs::path writeTempSerializedEntry(Entry::Level level,
+                                      const std::string& message, bool resolved)
+    {
+        auto tempEntryPath = tempEntryDir / std::to_string(entryId);
+
+        std::string entryMessage = message;
+        std::map<std::string, std::string> additionalData{{"TEST", "1"}};
+        AssociationList associations{};
+
+        auto entry = std::make_unique<Entry>(
+            bus, std::string(OBJ_ENTRY) + "/" + std::to_string(entryId),
+            entryId, 100, level, std::move(entryMessage),
+            std::move(additionalData), std::move(associations), "fw",
+            tempEntryPath.string(), *manager);
+
+        entry->resolved(resolved, true);
+        serialize(*entry, tempEntryDir);
+        return tempEntryPath;
+    }
+
+    void processPendingEvents()
+    {
+        sdeventplus::Event event(sdEvent);
+        event.run(std::chrono::milliseconds(1));
+    }
+
+    sdbusplus::SdBusMock sdbusMock;
+    sdbusplus::bus_t bus{nullptr};
+    std::unique_ptr<internal::Manager> manager;
+    sd_event* sdEvent{};
+    fs::path tempEntryDir;
+    fs::path repoEntryPath;
+    uint32_t entryId{};
+};
+
+TEST_F(LogManagerRedundantBMCSyncTest, EventLogRestore)
+{
+    manager->setupErrorFileWatch();
+
+    auto tempEntryPath = writeTempSerializedEntry(Entry::Level::Informational,
+                                                  "first message", false);
+
+    // Simulate sync moving the serialized event log into the watched repo
+    // path. The inotify handler should restore the entry from disk.
+    fs::rename(tempEntryPath, repoEntryPath);
+    processPendingEvents();
+
+    ASSERT_TRUE(manager->entries.contains(entryId));
+    EXPECT_EQ(manager->entries.at(entryId)->message(), "first message");
+    EXPECT_EQ(manager->entries.at(entryId)->resolved(), false);
+}
+
+TEST_F(LogManagerRedundantBMCSyncTest, EventLogRefresh)
+{
+    manager->setupErrorFileWatch();
+
+    auto tempEntryPath = writeTempSerializedEntry(Entry::Level::Informational,
+                                                  "first message", false);
+
+    // First move restores the synced event log entry into memory.
+    fs::rename(tempEntryPath, repoEntryPath);
+    processPendingEvents();
+
+    ASSERT_TRUE(manager->entries.contains(entryId));
+    EXPECT_EQ(manager->entries.at(entryId)->message(), "first message");
+    EXPECT_EQ(manager->entries.at(entryId)->resolved(), false);
+
+    tempEntryPath =
+        writeTempSerializedEntry(Entry::Level::Error, "updated message", true);
+
+    // Move an updated version of the same serialized file into place to
+    // simulate sync refreshing an existing event log entry.
+    fs::rename(tempEntryPath, repoEntryPath);
+    processPendingEvents();
+
+    ASSERT_TRUE(manager->entries.contains(entryId));
+    EXPECT_EQ(manager->entries.at(entryId)->message(), "updated message");
+    EXPECT_EQ(manager->entries.at(entryId)->resolved(), true);
+}
+
+TEST_F(LogManagerRedundantBMCSyncTest, EventLogDelete)
+{
+    manager->setupErrorFileWatch();
+
+    auto tempEntryPath = writeTempSerializedEntry(Entry::Level::Informational,
+                                                  "first message", false);
+
+    // First restore the entry so the delete path has something to remove.
+    fs::rename(tempEntryPath, repoEntryPath);
+    processPendingEvents();
+
+    ASSERT_TRUE(manager->entries.contains(entryId));
+
+    // Simulate sync removing the serialized event log file. The inotify
+    // handler should remove the corresponding in-memory entry.
+    fs::remove(repoEntryPath);
+    processPendingEvents();
+
+    EXPECT_FALSE(manager->entries.contains(entryId));
+}
+
+} // namespace phosphor::logging::test

--- a/test/meson.build
+++ b/test/meson.build
@@ -34,6 +34,11 @@ tests = [
     'serialization_test_path',
     'serialization_test_properties',
 ]
+
+if get_option('redundant-bmc')
+    tests += ['log_manager_rbmc_sync_test']
+endif
+
 foreach t : tests
     test(
         'test_' + t.underscorify(),

--- a/test/openpower-pels/log_id_test.cpp
+++ b/test/openpower-pels/log_id_test.cpp
@@ -108,17 +108,21 @@ TEST(LogIdTest, IDTestWithBMCPos)
     position::extractBMCPositionFromLogID(0x00000345);
     EXPECT_EQ(generatePELID(), 0x50000002);
 
-    // No Position
+    // No Position - generates time-based ID
     position::extractBMCPositionFromLogID(0xFF000678);
-    EXPECT_EQ(generatePELID(), 0x5F000003);
+    auto timeBasedID1 = generatePELID();
+    EXPECT_EQ(timeBasedID1 & 0xFF000000, 0x5F000000);
+    EXPECT_NE(timeBasedID1 & 0x00FFFFFF, 0x00000003);
 
     // Back to 0
     position::extractBMCPositionFromLogID(0x000009AB);
     EXPECT_EQ(generatePELID(), 0x50000004);
 
-    // Invalid, so PEL gets 0x5F
+    // Invalid, so PEL gets 0x5F with time-based ID
     position::extractBMCPositionFromLogID(0x39000CDE);
-    EXPECT_EQ(generatePELID(), 0x5F000005);
+    auto timeBasedID2 = generatePELID();
+    EXPECT_EQ(timeBasedID2 & 0xFF000000, 0x5F000000);
+    EXPECT_NE(timeBasedID2 & 0x00FFFFFF, 0x00000005);
 
     fs::remove_all(getPELIDFile().parent_path());
 }

--- a/test/openpower-pels/pel_manager_test.cpp
+++ b/test/openpower-pels/pel_manager_test.cpp
@@ -1517,7 +1517,9 @@ TEST_F(ManagerTest, TestCreatePELsWithBMCPosInID)
 
         // No position
         createPEL(manager, dir, 0xFF000002);
-        EXPECT_EQ(manager.getPELIdFromBMCLogId(0xFF000002), 0x5F000002);
+        auto pelId1 = manager.getPELIdFromBMCLogId(0xFF000002);
+        EXPECT_EQ(pelId1 & 0xFF000000, 0x5F000000);
+        EXPECT_NE(pelId1 & 0x00FFFFFF, 0x00000002);
 
         // Position 0
         createPEL(manager, dir, 0x00000003);
@@ -1525,6 +1527,8 @@ TEST_F(ManagerTest, TestCreatePELsWithBMCPosInID)
 
         // 0x93 is an invalid position, so will get a 0x5F PEL
         createPEL(manager, dir, 0x9300FFFF);
-        EXPECT_EQ(manager.getPELIdFromBMCLogId(0x9300FFFF), 0x5F000004);
+        auto pelId2 = manager.getPELIdFromBMCLogId(0x9300FFFF);
+        EXPECT_EQ(pelId2 & 0xFF000000, 0x5F000000);
+        EXPECT_NE(pelId2 & 0x00FFFFFF, 0x00000004);
     }
 }


### PR DESCRIPTION
#### PEL: Use epoch-based PEL IDs before BMC position is available
```
- In an RBMC system, both BMCs can create PELs before the
  BMC position file is available. In that case, both sides can
  generate PEL IDs with the same invalid position marker, which
  can cause ID conflicts when the PELs are later synchronized.

- Use an epoch-based PEL ID in this case to help avoid conflicts
  until the BMC position is determined.

Tested:
- Verified PELs are created with epoch-based IDs when BMC
  position is unavailable

Change-Id: Icdfb7ddb332c6833ff820abcf42d6392a62b6b46
Signed-off-by: Manish Tiwari <tmanish.in+openbmc@gmail.com>
```