### PR TITLE
1210: pels: Add phosphor-chassis-power journal capture to PSU fault PELs

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -3947,6 +3947,10 @@
             "JournalCapture": {
                 "Sections": [
                     {
+                        "SyslogID": "phosphor-chassis-power",
+                        "NumLines": 30
+                    },
+                    {
                         "SyslogID": "phosphor-psu-monitor",
                         "NumLines": 30
                     },
@@ -3992,6 +3996,10 @@
             },
             "JournalCapture": {
                 "Sections": [
+                    {
+                        "SyslogID": "phosphor-chassis-power",
+                        "NumLines": 30
+                    },
                     {
                         "SyslogID": "phosphor-psu-monitor",
                         "NumLines": 30
@@ -4039,6 +4047,10 @@
             "JournalCapture": {
                 "Sections": [
                     {
+                        "SyslogID": "phosphor-chassis-power",
+                        "NumLines": 30
+                    },
+                    {
                         "SyslogID": "phosphor-psu-monitor",
                         "NumLines": 30
                     },
@@ -4084,6 +4096,10 @@
             },
             "JournalCapture": {
                 "Sections": [
+                    {
+                        "SyslogID": "phosphor-chassis-power",
+                        "NumLines": 30
+                    },
                     {
                         "SyslogID": "phosphor-psu-monitor",
                         "NumLines": 30


### PR DESCRIPTION
#### pels: Add phosphor-chassis-power journal capture to PSU fault PELs
```
Add phosphor-chassis-power journal sections (30 lines each) to the
JournalCapture configuration for four PSU-related PEL entries. This
ensures that chassis power service logs are captured alongside PSU
monitor logs when these faults are reported, improving debug visibility
for standby power fault scenarios.

Change-Id: I1611429b80295f4ba54826cb20c88495449a0ee0
Signed-off-by: Sheldon Bailey <baileysh@us.ibm.com>
```