### PR TITLE
pel: Add RTC read failure registry entry

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6837,6 +6837,29 @@
                 "Message": "Acf script ended running in the shell",
                 "Notes": ["The journal should contain more information"]
             }
+        },
+        {
+            "Name": "xyz.openbmc_project.Time.Error.RTCReadFailure",
+            "Subsystem": "cec_tod",
+            "ComponentID": "0x1000",
+            "Severity": "critical",
+            "ActionFlags": ["report"],
+
+            "SRC": {
+                "ReasonCode": "0x1010",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "BMC RTC read failure",
+                "Message": "Failed to read the RTC. System date may be invalid. If NTP is disabled, set the correct date/time via ASMI before powering on",
+                "Notes": [
+                    "Generated when the BMC fails to read the RTC.",
+                    "If NTP is enabled, the system time is expected to recover automatically after synchronization.",
+                    "If NTP is disabled, manually setting the correct system time updates the RTC ",
+                    "RTC hardware replacement is generally not required unless the failure persists.."
+                ]
+            }            
         }
     ]
 }


### PR DESCRIPTION
This commit adds a new message registry entry for BMC RTC (Real-Time Clock) read failures.

When the BMC is unable to read the RTC, the system may boot with an incorrect (default/epoch) time. If the host is IPLed while the BMC time is incorrect, the incorrect time may be propagated to the host during the IPL process. Depending on the host's Time-of-Day (TOD) validation, a significant mismatch may result in the IPL being halted.

**About the PEL:**
**Severity**: RTC read failures can result in an invalid BMC time, which may impact host IPL. The event is therefore logged with a critical severity to ensure prompt attention

**ActionFlags**: The event is reported for diagnosis but does not request hardware replacement or trigger a call-home action

**Message**: Instructs the engineer for the required procedure.