### PR TITLE
pel: Add RTC read failure registry entry

### DIFF
--- a/extensions/openpower-pels/registry/O_component_ids.json
+++ b/extensions/openpower-pels/registry/O_component_ids.json
@@ -20,5 +20,6 @@
     "E500": "bmc hw diags",
     "F100": "bmc faultlog",
     "F300": "bmc memory ECC errors",
-    "F500": "bmc acfshell"
+    "F500": "bmc acfshell",
+    "F600": "bmc time management"
 }

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6837,6 +6837,29 @@
                 "Message": "Acf script ended running in the shell",
                 "Notes": ["The journal should contain more information"]
             }
+        },
+        {
+            "Name": "xyz.openbmc_project.Time.Error.RTCReadFailure",
+            "Subsystem": "cec_tod",
+            "ComponentID": "0xF600",
+            "Severity": "critical",
+            "ActionFlags": ["report"],
+
+            "SRC": {
+                "ReasonCode": "0xF601",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "BMC RTC read failure",
+                "Message": "Failed to read the RTC. System date may be invalid. If NTP is disabled, set the correct date/time via ASMI before powering on",
+                "Notes": [
+                    "Generated when the BMC fails to read the RTC.",
+                    "If NTP is enabled, the system time is expected to recover automatically after synchronization.",
+                    "If NTP is disabled, manually setting the correct system time updates the RTC ",
+                    "RTC hardware replacement is generally not required unless the failure persists.."
+                ]
+            }
         }
     ]
 }

--- a/tools/elog-gen.py
+++ b/tools/elog-gen.py
@@ -324,7 +324,7 @@ def main(i_args):
         help="Base directory of files to process",
     )
 
-    (options, args) = parser.parse_args(i_args)
+    options, args = parser.parse_args(i_args)
 
     gen_elog_hpp(
         options.yamldir,


### PR DESCRIPTION
pel: Add RTC read failure registry entry

the change is already merged upstream 
[https://github.com/openbmc/phosphor-logging/commit/f88d6ff2b73df59418067f3bf71ce1b3638c7926]


Change-Id: I68a11c3598cf043b1320122d005ef17b029580e3
Signed-off-by: Sachin Shukla <shuklasachin144@gmail.com>