### PR TITLE
pel: Add RTC read failure registry entry (#152)

### DIFF
--- a/extensions/openpower-pels/registry/O_component_ids.json
+++ b/extensions/openpower-pels/registry/O_component_ids.json
@@ -19,5 +19,6 @@
     "D100": "bmc hw diags attention handler",
     "E500": "bmc hw diags",
     "F100": "bmc faultlog",
-    "F300": "bmc memory ECC errors"
+    "F300": "bmc memory ECC errors",
+    "F600": "bmc time management"
 }

--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -6569,6 +6569,29 @@
                     "the additional user data section."
                 ]
             }
+        },
+        {
+            "Name": "xyz.openbmc_project.Time.Error.RTCReadFailure",
+            "Subsystem": "cec_tod",
+            "ComponentID": "0xF600",
+            "Severity": "critical",
+            "ActionFlags": ["report"],
+
+            "SRC": {
+                "ReasonCode": "0xF601",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "BMC RTC read failure",
+                "Message": "Failed to read the RTC. System date may be invalid. If NTP is disabled, set the correct date/time via ASMI before powering on",
+                "Notes": [
+                    "Generated when the BMC fails to read the RTC.",
+                    "If NTP is enabled, the system time is expected to recover automatically after synchronization.",
+                    "If NTP is disabled, manually setting the correct system time updates the RTC ",
+                    "RTC hardware replacement is generally not required unless the failure persists.."
+                ]
+            }
         }
     ]
 }

--- a/tools/elog-gen.py
+++ b/tools/elog-gen.py
@@ -324,7 +324,7 @@ def main(i_args):
         help="Base directory of files to process",
     )
 
-    (options, args) = parser.parse_args(i_args)
+    options, args = parser.parse_args(i_args)
 
     gen_elog_hpp(
         options.yamldir,


### PR DESCRIPTION
Backport the RTC read failure PEL registry entry to the 1110 branch.

This is a backport of the change already merged into the 1120 branch:
[https://github.com/ibm-openbmc/phosphor-logging/commit/e5e15e6ae6f76406f866a8e44db8f6d005ca4b1e]


Change-Id: I68a11c3598cf043b1320122d005ef17b029580e3


* Fix linter errors related to tuples

Simple change based on lint recommendation

Change-Id: I7a575d244d59adf3e537bc28e5ed0371ad733e8e


---------