### PR TITLE
1210: pel: repurposed unused SBE vital attention registry entry

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -2031,7 +2031,7 @@
         },
 
         {
-            "Name": "org.open_power.Attn.Error.Vital",
+            "Name": "org.open_power.Attn.Error.Sbe",
             "Subsystem": "processor_chip",
 
             "SRC": {
@@ -2040,10 +2040,10 @@
             },
 
             "Documentation": {
-                "Description": "Status shows SBE vital attention active",
-                "Message": "SBE vital attention detected",
+                "Description": "Status shows an SBE attention active",
+                "Message": "SBE attention detected",
                 "Notes": [
-                    "This entry is for any SBE vital attention event ",
+                    "This entry is for any SBE attention event ",
                     "reported by the attention handler component"
                 ]
             }


### PR DESCRIPTION
#### pel: repurposed unused SBE vital attention registry entry
```
The SBE vital attention was never used. Made the entry more generic for
any SBE attention.

Change-Id: I189fa5dcc5647fad1a275e16cda70e462e0cb23e
Signed-off-by: Zane Shelley <zshelle@us.ibm.com>
```