### PR TITLE
pel: Add unexpected chassis status registry entry

### DIFF
--- a/extensions/openpower-pels/registry/message_registry.json
+++ b/extensions/openpower-pels/registry/message_registry.json
@@ -2700,6 +2700,50 @@
         },
 
         {
+            "Name": "xyz.openbmc_project.Power.PowerSequencer.UnexpectedChassisStatus",
+            "Subsystem": "power_sequencer",
+            "ComponentID": "0x2700",
+            "Severity": "non_error",
+
+            "SRC": {
+                "Type": "11",
+                "ReasonCode": "0x1F06",
+                "Words6To9": {}
+            },
+
+            "Documentation": {
+                "Description": "Chassis was in an unexpected state during a power on or power off",
+                "Message": "Chassis was in an unexpected state during a power on or power off",
+                "Notes": []
+            },
+
+            "JournalCapture": {
+                "Sections": [
+                    {
+                        "SyslogID": "phosphor-power-control",
+                        "NumLines": 30
+                    },
+                    {
+                        "SyslogID": "phosphor-psu-monitor",
+                        "NumLines": 30
+                    },
+                    {
+                        "SyslogID": "phosphor-chassis-state-manager",
+                        "NumLines": 15
+                    },
+                    {
+                        "SyslogID": "systemd",
+                        "NumLines": 15
+                    },
+                    {
+                        "SyslogID": "phosphor-regulators",
+                        "NumLines": 5
+                    }
+                ]
+            }
+        },
+
+        {
             "Name": "xyz.openbmc_project.State.Shutdown.Power.Error.Blackout",
             "Subsystem": "power",
             "ActionFlags": ["report", "service_action"],


### PR DESCRIPTION
Add an informational (non_error) entry to the message registry for scenarios where the chassis status is unexpected during a power on or power off.

For example, during a power on, a chassis is not available or is de-configured.

Other applications should have logged non-informational errors explaining the cause of this chassis status. The purpose of this informational entry is to explain why a chassis was not selected for power on/power off or that it changed status during a power on.

Tested:
- Created error log using new message registry entry. Validated resulting property values in the error log.

Change-Id: Ib48c149374aaa20a6dc11c64e4604e432b76d2ee