### PR TITLE
 Return object path in CreateWithFFDCFiles

### DIFF
--- a/log_manager.hpp
+++ b/log_manager.hpp
@@ -455,14 +455,14 @@ class Manager : public details::ServerObject<DeleteAllIface, CreateIface>
      * @param[in] additionalData - The AdditionalData property for the error
      * @param[in] ffdc - A vector of FFDC file info
      */
-    void createWithFFDCFiles(
+    auto createWithFFDCFiles(
         std::string message, Severity severity,
         std::map<std::string, std::string> additionalData,
         std::vector<std::tuple<CreateIface::FFDCFormat, uint8_t, uint8_t,
                                sdbusplus::message::unix_fd>>
-            ffdc) override
+            ffdc) -> sdbusplus::object_path override
     {
-        manager.create(message, severity, additionalData, ffdc);
+        return manager.create(message, severity, additionalData, ffdc);
     }
 
   private:

--- a/test/openpower-pels/src_test.cpp
+++ b/test/openpower-pels/src_test.cpp
@@ -349,7 +349,7 @@ TEST_F(SRCTest, InventoryCalloutNoLocCodeTest)
 
     EXPECT_CALL(dataIface, getLocationCode("motherboard"))
         .Times(1)
-        .WillOnce(InvokeWithoutArgs(func));
+        .WillOnce(func);
 
     EXPECT_CALL(dataIface, getHWCalloutFields(_, _, _, _)).Times(0);
 
@@ -391,7 +391,7 @@ TEST_F(SRCTest, InventoryCalloutNoVPDTest)
 
     EXPECT_CALL(dataIface, getHWCalloutFields("motherboard", _, _, _))
         .Times(1)
-        .WillOnce(InvokeWithoutArgs(func));
+        .WillOnce(func);
 
     SRC src{entry, ad, dataIface};
     EXPECT_TRUE(src.valid());


### PR DESCRIPTION
 Just like Create already does, return the object path of the event log created.